### PR TITLE
Validate logs before SetLevel

### DIFF
--- a/config.go
+++ b/config.go
@@ -135,9 +135,9 @@ func initConfig() error {
 	}
 	// Update config from the TOML configuration file.
 	if configFile == "" {
-		log.Debug("Skipping confd config file.")
+		log.Info("Skipping confd config file.")
 	} else {
-		log.Debug("Loading " + configFile)
+		log.Info("Loading " + configFile)
 		configBytes, err := ioutil.ReadFile(configFile)
 		if err != nil {
 			return err


### PR DESCRIPTION
A default log level of confd/log will be Info.
So log level before SetLevel should be Info or above.