### PR TITLE
Add a simple dockerfile for calico/confd

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-bin
 vendor
 pkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM alpine
+LABEL maintainer "Casey Davenport <casey@tigera.io>"
+
+# Copy in the binary. 
+ADD bin/confd /bin/confd 

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ vendor vendor/.up-to-date: glide.lock
 	$(DOCKER_GO_BUILD) glide install --strip-vendor
 	touch vendor/.up-to-date
 
+container: bin/confd
+	docker build -t calico/confd .
+
 bin/confd: $(GO_FILES) vendor/.up-to-date
 	@echo Building confd...
 	$(DOCKER_GO_BUILD) \


### PR DESCRIPTION
Add a Dockerfile to build a `calico/confd` image which contains the confd binary.

Part of making our build process more consistent - we can follow the same approach for shipping confd as we do for Felix.