### PR TITLE
Fix up log level from env var

### DIFF
--- a/confd.go
+++ b/confd.go
@@ -8,8 +8,8 @@ import (
 	"syscall"
 
 	"github.com/kelseyhightower/confd/backends"
-	"github.com/kelseyhightower/confd/log"
 	"github.com/kelseyhightower/confd/resource/template"
+	log "github.com/sirupsen/logrus"
 )
 
 var VERSION string

--- a/config.go
+++ b/config.go
@@ -12,8 +12,9 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/kelseyhightower/confd/backends"
-	"github.com/kelseyhightower/confd/log"
+	logutils "github.com/kelseyhightower/confd/log"
 	"github.com/kelseyhightower/confd/resource/template"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -23,7 +24,6 @@ var (
 	config            Config // holds the global confd config.
 	interval          int
 	keepStageFile     bool
-	logLevel          string
 	noop              bool
 	onetime           bool
 	prefix            string
@@ -41,7 +41,6 @@ type Config struct {
 	Noop         bool   `toml:"noop"`
 	Prefix       string `toml:"prefix"`
 	SyncOnly     bool   `toml:"sync-only"`
-	LogLevel     string `toml:"log-level"`
 	CalicoConfig string `toml:"calicoconfig"`
 }
 
@@ -50,7 +49,6 @@ func init() {
 	flag.StringVar(&configFile, "config-file", "", "the confd config file")
 	flag.IntVar(&interval, "interval", 600, "backend polling interval")
 	flag.BoolVar(&keepStageFile, "keep-stage-file", false, "keep staged files")
-	flag.StringVar(&logLevel, "log-level", "", "level which confd should log messages")
 	flag.BoolVar(&noop, "noop", false, "only show pending changes")
 	flag.BoolVar(&onetime, "onetime", false, "run once and exit")
 	flag.StringVar(&prefix, "prefix", "", "key path prefix")
@@ -94,12 +92,12 @@ func initConfig() error {
 	// Update config from commandline flags.
 	processFlags()
 
-	if config.LogLevel != "" {
+	if level := os.Getenv("BGP_LOGSEVERITYSCREEN"); level != "" {
 		// If specified, use the provided log level.
-		log.SetLevel(config.LogLevel)
+		logutils.SetLevel(level)
 	} else {
 		// Default to info level logs.
-		log.SetLevel("info")
+		logutils.SetLevel("info")
 	}
 
 	backendsConfig = backends.Config{
@@ -152,8 +150,6 @@ func setConfigFromFlag(f *flag.Flag) {
 		config.Prefix = prefix
 	case "sync-only":
 		config.SyncOnly = syncOnly
-	case "log-level":
-		config.LogLevel = logLevel
 	case "calicoconfig":
 		config.CalicoConfig = calicoconfig
 	}

--- a/log/log.go
+++ b/log/log.go
@@ -8,7 +8,6 @@ Log entries will be logged in the following format:
 package log
 
 import (
-	"fmt"
 	"os"
 
 	log "github.com/sirupsen/logrus"
@@ -40,29 +39,4 @@ func SetLevel(level string) {
 		return
 	}
 	log.SetLevel(lvl)
-}
-
-// Debug logs a message with severity DEBUG.
-func Debug(format string, v ...interface{}) {
-	log.Debug(fmt.Sprintf(format, v...))
-}
-
-// Error logs a message with severity ERROR.
-func Error(format string, v ...interface{}) {
-	log.Error(fmt.Sprintf(format, v...))
-}
-
-// Fatal logs a message with severity ERROR followed by a call to os.Exit().
-func Fatal(format string, v ...interface{}) {
-	log.Fatal(fmt.Sprintf(format, v...))
-}
-
-// Info logs a message with severity INFO.
-func Info(format string, v ...interface{}) {
-	log.Info(fmt.Sprintf(format, v...))
-}
-
-// Warning logs a message with severity WARNING.
-func Warning(format string, v ...interface{}) {
-	log.Warning(fmt.Sprintf(format, v...))
 }

--- a/resource/template/processor.go
+++ b/resource/template/processor.go
@@ -5,12 +5,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kelseyhightower/confd/log"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
 	initialProcessRetryInterval = 250 * time.Millisecond
-	maxProcessRetryInterval = 5 * time.Second
+	maxProcessRetryInterval     = 5 * time.Second
 )
 
 type Processor interface {
@@ -125,7 +125,7 @@ func (p *watchProcessor) monitorPrefix(t *TemplateResource) {
 			// check function for this template is dependent on the other templates being rendered.
 			// Rather than blocking on WatchPrefix, sleep for a short period and retry - we'll start
 			// with short retry intervals and increase up to 5s.
-			log.Debug("Will retry processing the template in %s", retryInterval)
+			log.Debugf("Will retry processing the template in %s", retryInterval)
 			p.errChan <- err
 			time.Sleep(retryInterval)
 			retryInterval *= 2

--- a/resource/template/resource.go
+++ b/resource/template/resource.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/kelseyhightower/confd/backends"
-	"github.com/kelseyhightower/confd/log"
 	"github.com/kelseyhightower/memkv"
+	log "github.com/sirupsen/logrus"
 )
 
 type Config struct {

--- a/resource/template/util.go
+++ b/resource/template/util.go
@@ -6,7 +6,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/kelseyhightower/confd/log"
+	log "github.com/sirupsen/logrus"
 )
 
 // fileInfo describes a configuration file and is returned by fileStat.

--- a/tests/test_suite_common.sh
+++ b/tests/test_suite_common.sh
@@ -43,7 +43,7 @@ execute_test_suite() {
 execute_tests_daemon() {
     # Run confd as a background process.
     echo "Running confd as background process"
-    confd -confdir=/etc/calico/confd -log-level=debug >$LOGPATH/logd1 2>&1 &
+    BGP_LOGSEVERITYSCREEN="debug" confd -confdir=/etc/calico/confd >$LOGPATH/logd1 2>&1 &
     CONFD_PID=$!
     echo "Running with PID " $CONFD_PID
 
@@ -61,7 +61,7 @@ execute_tests_daemon() {
 
     # Re-start a background confd.
     echo "Restarting confd"
-    confd -confdir=/etc/calico/confd -log-level=debug >$LOGPATH/logd2 2>&1 &
+    BGP_LOGSEVERITYSCREEN="debug" confd -confdir=/etc/calico/confd >$LOGPATH/logd2 2>&1 &
     CONFD_PID=$!
     ps
 
@@ -148,7 +148,7 @@ run_individual_test_oneshot() {
     calicoctl apply -f /tests/mock_data/calicoctl/${testdir}/input.yaml
 
     # Run confd in oneshot mode.
-    confd -confdir=/etc/calico/confd -onetime -log-level=debug >$LOGPATH/logss 2>&1 || true
+    BGP_LOGSEVERITYSCREEN="debug" confd -confdir=/etc/calico/confd -onetime >$LOGPATH/logss 2>&1 || true
 
     # Check the confd templates are updated.
     test_confd_templates $testdir


### PR DESCRIPTION
- Correctly set log severity from env var at start of day. 
- Remove support for the cli flag `--log-level`
- Use logrus directly, so the correct line numbers and file names appear in log output.