### PR TITLE
Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-bin
 vendor
 pkg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM alpine
+LABEL maintainer "Casey Davenport <casey@tigera.io>"
+
+# Copy in the binary. 
+ADD bin/confd /bin/confd 

--- a/Makefile
+++ b/Makefile
@@ -139,9 +139,6 @@ bin/bird6:
 bin/etcdctl:
 	curl -sSf -L --retry 5  https://github.com/coreos/etcd/releases/download/$(ETCD_VER)/etcd-$(ETCD_VER)-linux-$(ARCH).tar.gz | tar -xz -C bin --strip-components=1 etcd-$(ETCD_VER)-linux-$(ARCH)/etcdctl 
 
-container:
-	@echo success!
-
 .PHONY: clean
 clean:
 	rm -rf bin/*

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ vendor vendor/.up-to-date: glide.lock
 	$(DOCKER_GO_BUILD) glide install --strip-vendor
 	touch vendor/.up-to-date
 
+container: bin/confd
+	docker build -t calico/confd .
+
 bin/confd: $(GO_FILES) vendor/.up-to-date
 	@echo Building confd...
 	$(DOCKER_GO_BUILD) \


### PR DESCRIPTION
@caseydavenport - this is a cherry-pick of your https://github.com/projectcalico/confd/pull/55.

I think we need this in order to get the `confd` executables in calico/node since the current v2.6.x branch expects to be able to curl a release.