### PR TITLE
backport fix for `make release VERSION=?`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ ETCD_VER=v3.2.5
 BIRD_VER=v0.3.1
 LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | awk '{print $$7}')
 
+CONFD_VERSION?=$(shell git describe --tags --dirty --always)
+LDFLAGS=-ldflags "-X main.VERSION=$(CONFD_VERSION)"
+
 # Ensure that the bin directory is always created
 MAKE_SURE_BIN_EXIST := $(shell mkdir -p bin)
 
@@ -71,7 +74,7 @@ container: bin/confd
 bin/confd: $(GO_FILES) vendor/.up-to-date
 	@echo Building confd...
 	$(DOCKER_GO_BUILD) \
-	    sh -c 'go build -v -i -o $@ "github.com/kelseyhightower/confd" && \
+	    sh -c 'go build -v -i -o $@ $(LDFLAGS) "github.com/kelseyhightower/confd" && \
 		( ldd bin/confd 2>&1 | grep -q -e "Not a valid dynamic program" \
 			-e "not a dynamic executable" || \
 	             ( echo "Error: bin/confd was not statically linked"; false ) )'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,20 @@
+# Release process
+
+## Resulting artifacts
+Creating a new release creates the following artifact
+* `bin/confd`
+
+## Preparing for a release
+Ensure that the branch you want to release from (typically master) is in a good state.
+e.g. Update any pins in glide.yaml
+
+You should have no local changes and tests should be passing.
+
+Verify that the versions of calicoctl etc. at the top of the Makefile are correct, and that
+glide has been revved to the appropriate version of libcalico-go.
+
+## Creating the release
+
+1. Run `make release VERSION=<version>` and follow the steps.
+1. Create a release on Github, using the tag which was just pushed.
+1. Update the `confd` artifact on github.com

--- a/confd.go
+++ b/confd.go
@@ -12,10 +12,12 @@ import (
 	"github.com/kelseyhightower/confd/resource/template"
 )
 
+var VERSION string
+
 func main() {
 	flag.Parse()
 	if printVersion {
-		fmt.Printf("confd %s\n", Version)
+		fmt.Printf("confd %s\n", VERSION)
 		os.Exit(0)
 	}
 	if err := initConfig(); err != nil {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,0 @@
-package main
-
-const Version = "v0.12.1-calico-0.4.1"


### PR DESCRIPTION
Backport of a couple of @caseydavenport 's fixes to take the VERSION as a make arg rather than a hardwired string `version.go`.