### PR TITLE
Adding Dockerfile-ppc64le and updating the Makefile to use it.

### DIFF
--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -1,0 +1,19 @@
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
+# Copyright IBM Corp. 2018
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM ppc64le/alpine
+LABEL maintainer "David Wilder <wilder@us.ibm.com>"
+
+# Copy in the binary. 
+ADD bin/confd /bin/confd 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ all: clean test
 GO_BUILD_CONTAINER?=calico/go-build$(ARCHTAG):$(GO_BUILD_VER)
 
 CALICOCTL_VER=master
-CALICOCTL_CONTAINER_NAME=calico/ctl:$(CALICOCTL_VER)
+CALICOCTL_CONTAINER_NAME=calico/ctl$(ARCHTAG):$(CALICOCTL_VER)
 K8S_VERSION=v1.8.1
 ETCD_VER=v3.2.5
 BIRD_VER=v0.3.1
@@ -71,7 +71,7 @@ vendor vendor/.up-to-date: glide.lock
 	touch vendor/.up-to-date
 
 container: bin/confd
-	docker build -t calico/confd .
+	docker build -t calico/confd$(ARCHTAG) -f Dockerfile$(ARCHTAG) .
 
 bin/confd: $(GO_FILES) vendor/.up-to-date
 	@echo Building confd...


### PR DESCRIPTION
This makes the ppc64le build process more consistent with other
architectures. Make CALICOCTL_CONTAINER_NAME architecture specific.

Signed-off-by: David Wilder <wilder@us.ibm.com>