### PR TITLE
Add CMD stanza to Dockerfiles.

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -16,3 +16,5 @@ LABEL maintainer "Casey Davenport <casey@tigera.io>"
 
 # Copy in the binary.
 ADD bin/confd-amd64 /bin/confd
+
+CMD /bin/confd

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -17,3 +17,5 @@ LABEL maintainer "David Wilder <wilder@us.ibm.com>"
 
 # Copy in the binary.
 ADD bin/confd-arm64 /bin/confd
+
+CMD /bin/confd

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -17,3 +17,5 @@ LABEL maintainer "David Wilder <wilder@us.ibm.com>"
 
 # Copy in the binary.
 ADD bin/confd-ppc64le /bin/confd
+
+CMD /bin/confd

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -17,3 +17,5 @@ LABEL maintainer "David Wilder <wilder@us.ibm.com>"
 
 # Copy in the binary.
 ADD bin/confd-s390x /bin/confd
+
+CMD /bin/confd


### PR DESCRIPTION
Without this, downstream builds fail because they can't even create a docker container from the confd image.