### PR TITLE
Replicate all semaphore activities in ci and cd targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,25 @@ vendor vendor/.up-to-date: glide.lock
 	$(DOCKER_GO_BUILD) glide install --strip-vendor
 	touch vendor/.up-to-date
 
+
+###############################################################################
+# standard ci/cd targets
+###############################################################################
+
+## Builds the code and runs all tests.
+ci: all container
+
+## Deploys images to registry
+cd:
+ifndef CONFIRM
+	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
+endif
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
+endif
+	$(MAKE) tag-images push IMAGETAG=${BRANCH_NAME}
+	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
+
 ###############################################################################
 # tag and push images of any tag
 ###############################################################################


### PR DESCRIPTION
Replicate the workflow from kube-controllers PR here:

* Create a `make ci` target that does everything in the various semaphore jobs except tag images and push to registries
* Create a `make cd` target that only tags images and pushes to registries

As discussed with @caseydavenport @fasaxc @tomdee
