### PR TITLE
Fix linter issues and ignore notExist error for remove.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ static-checks: vendor
 		-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 		-v $(CURDIR):/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
-		$(CALICO_BUILD) gometalinter --deadline=300s --disable-all --enable=goimports --vendor ./...
+		$(CALICO_BUILD) \
+		gometalinter --deadline=300s --disable-all --enable=vet --enable=errcheck  --enable=goimports --vendor ./...
 
 .PHONY: fix
 ## Fix static checks

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -332,7 +332,7 @@ func (c *client) WatchPrefix(prefix string, keys []string, lastRevision uint64, 
 		for _, key := range keys {
 			rev, ok := c.revisionsByPrefix[key]
 			if !ok {
-				log.Fatalf("Watch prefix check for unknown prefix: ", key)
+				log.Fatalf("Watch prefix check for unknown prefix: %s", key)
 			}
 			log.Debugf("Found key prefix %s at rev %d", key, rev)
 			if rev > lastRevision {

--- a/pkg/resource/template/fileStat_posix.go
+++ b/pkg/resource/template/fileStat_posix.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"os"
 	"syscall"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // fileStat return a fileInfo describing the named file.
@@ -18,13 +20,22 @@ func fileStat(name string) (fi fileInfo, err error) {
 		if err != nil {
 			return fi, err
 		}
-		defer f.Close()
-		stats, _ := f.Stat()
+		defer func() {
+			if e := f.Close(); e != nil {
+				log.WithError(e).WithField("filename", name).Error("error closing file")
+			}
+		}()
+		stats, err := f.Stat()
+		if err != nil {
+			return fi, err
+		}
 		fi.Uid = stats.Sys().(*syscall.Stat_t).Uid
 		fi.Gid = stats.Sys().(*syscall.Stat_t).Gid
 		fi.Mode = stats.Mode()
 		h := md5.New()
-		io.Copy(h, f)
+		if _, err := io.Copy(h, f); err != nil {
+			return fileInfo{}, err
+		}
 		fi.Md5 = fmt.Sprintf("%x", h.Sum(nil))
 		return fi, nil
 	}

--- a/pkg/resource/template/processor.go
+++ b/pkg/resource/template/processor.go
@@ -68,8 +68,7 @@ type watchProcessor struct {
 }
 
 func WatchProcessor(config Config, stopChan, doneChan chan bool, errChan chan error) Processor {
-	var wg sync.WaitGroup
-	return &watchProcessor{config, stopChan, doneChan, errChan, wg}
+	return &watchProcessor{config, stopChan, doneChan, errChan, sync.WaitGroup{}}
 }
 
 func (p *watchProcessor) Process() {


### PR DESCRIPTION
Fixes lint issues listed in https://github.com/projectcalico/confd/issues/126
Also fix an issue where the code was returning an error when `os.Remove` returned an error when the file did not exist. This was causing the tests to slow down.

cc @tomdee 