### PR TITLE
Ignore environment variables whose value is "none"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,7 +195,7 @@ func readTyphaConfig(typhaConfig *TyphaConfig) {
 		nameUpper := strings.ToUpper(field.Name)
 		for _, prefix := range supportedPrefixes {
 			varName := prefix + "TYPHA" + nameUpper
-			if value := os.Getenv(varName); value != "" {
+			if value := os.Getenv(varName); value != "" && value != "none" {
 				log.Infof("Found %v=%v", varName, value)
 				if field.Type.Name() == "Duration" {
 					seconds, err := strconv.ParseFloat(value, 64)


### PR DESCRIPTION
"none" is supposed to mean setting to the zero value for the relevant
config.  In confd all the Typha config fields are at their zero value
anyway, unless the environment configures them, so we can simply ignore
"none" values.

We _should_ ignore "none" values because otherwise we can try to look
for a Kubernetes service named "none".