### PR TITLE
For oneshot testing, run Typha each time after prepping datastore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,13 +177,7 @@ fix:
 ###############################################################################
 .PHONY: test-kdd
 ## Run template tests against KDD
-test-kdd: bin/confd bin/kubectl bin/bird bin/bird6 bin/calico-node bin/calicoctl run-k8s-apiserver
-	-docker rm -f confd-typha
-	docker run -d --rm --net=host --name=confd-typha \
-		-v $(CURDIR)/tests/:/tests/ \
-		-e TYPHA_DATASTORETYPE=kubernetes \
-		-e KUBECONFIG=/tests/confd_kubeconfig \
-                 $(TYPHA_CONTAINER_NAME)
+test-kdd: bin/confd bin/kubectl bin/bird bin/bird6 bin/calico-node bin/calicoctl bin/typha run-k8s-apiserver
 	docker run --rm --net=host \
 		-v $(CURDIR)/tests/:/tests/ \
 		-v $(CURDIR)/bin:/calico/bin/ \
@@ -201,11 +195,10 @@ test-kdd: bin/confd bin/kubectl bin/bird bin/bird6 bin/calico-node bin/calicoctl
 	    cat tests/logs/kdd/logd1 || true; \
 	    echo; \
 	    echo === Typha log:; \
-	    docker logs confd-typha 2>&1; \
+	    cat tests/logs/kdd/typha || true; \
 	    echo; \
             false; \
         }
-	docker rm -f confd-typha
 
 .PHONY: test-etcd
 ## Run template tests against etcd
@@ -283,6 +276,18 @@ bin/calicoctl:
 	  test -e $@ && \
 	  touch $@
 	-docker rm -f calico-ctl
+
+bin/typha:
+	-docker rm -f confd-typha
+	docker pull $(TYPHA_CONTAINER_NAME)
+	docker create --name confd-typha $(TYPHA_CONTAINER_NAME)
+	# Then we copy the files out of the container.  Since docker preserves
+	# mtimes on its copy, check the file really did appear, then touch it
+	# to make sure that downstream targets get rebuilt.
+	docker cp confd-typha:/code/calico-typha $@ && \
+	  test -e $@ && \
+	  touch $@
+	-docker rm -f confd-typha
 
 ###############################################################################
 # CI


### PR DESCRIPTION
Otherwise what happens is that Typha is already in-sync before the
calicoctl changes needed for the next test have gone through.  confd
thinks it can process templates as soon as the datastore is in sync, so
then we just get a race between confd and some of the resources getting
through.

With this change, the sequencing for each oneshot test is:

1. populate the datastore as needed for the test
2. start Typha
3. start confd
4. check templates
5. kill Typha

Then the first in-sync is guaranteed to include the datastore view that
the test needs.