### PR TITLE
Fix new peer handling for IPv6 as well as IPv4

### DIFF
--- a/tests/compiled_templates/etcdv3/explicit_peering/selectors/bird6.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/selectors/bird6.cfg
@@ -42,5 +42,51 @@ protocol direct {
   interface -"cali*", "*"; # Exclude cali* but include everything else.
 }
 
-# IPv6 disabled on this node.
+
+# Template for all BGP clients
+template bgp bgp_template {
+  
+
+  debug { states };
+
+
+  description "Connection to BGP peer";
+  local as 64512;
+  multihop;
+  gateway recursive; # This should be the default, but just in case.
+  import all;        # Import all routes, since we don't know what the upstream
+                     # topology is and therefore have to trust the ToR/RR.
+  export filter calico_pools;  # Only want to export routes for workloads.
+  source address fd5f::2;  # The local address we use for the TCP connection
+  add paths on;
+  graceful restart;  # See comment in kernel section about graceful restart.
+}
+
+# ------------- Node-to-node mesh -------------
+
+# Node-to-node mesh disabled
+
+
+
+# ------------- Global peers -------------
+# No global peers configured.
+
+
+# ------------- Node-specific peers -------------
+
+
+
+
+# For peer /host/kube-master/peer_v6/fd5f::3
+protocol bgp Node_fd5f__3 from bgp_template {
+  neighbor fd5f::3 as 64512;
+}
+
+
+# For peer /host/kube-master/peer_v6/fd5f::4
+protocol bgp Node_fd5f__4 from bgp_template {
+  neighbor fd5f::4 as 64512;
+}
+
+
 

--- a/tests/compiled_templates/kubernetes/explicit_peering/selectors/bird6.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/selectors/bird6.cfg
@@ -42,5 +42,51 @@ protocol direct {
   interface -"cali*", "*"; # Exclude cali* but include everything else.
 }
 
-# IPv6 disabled on this node.
+
+# Template for all BGP clients
+template bgp bgp_template {
+  
+
+  debug { states };
+
+
+  description "Connection to BGP peer";
+  local as 64512;
+  multihop;
+  gateway recursive; # This should be the default, but just in case.
+  import all;        # Import all routes, since we don't know what the upstream
+                     # topology is and therefore have to trust the ToR/RR.
+  export filter calico_pools;  # Only want to export routes for workloads.
+  source address fd5f::2;  # The local address we use for the TCP connection
+  add paths on;
+  graceful restart;  # See comment in kernel section about graceful restart.
+}
+
+# ------------- Node-to-node mesh -------------
+
+# Node-to-node mesh disabled
+
+
+
+# ------------- Global peers -------------
+# No global peers configured.
+
+
+# ------------- Node-specific peers -------------
+
+
+
+
+# For peer /host/kube-master/peer_v6/fd5f::3
+protocol bgp Node_fd5f__3 from bgp_template {
+  neighbor fd5f::3 as 64512;
+}
+
+
+# For peer /host/kube-master/peer_v6/fd5f::4
+protocol bgp Node_fd5f__4 from bgp_template {
+  neighbor fd5f::4 as 64512;
+}
+
+
 

--- a/tests/mock_data/calicoctl/explicit_peering/selectors/input.yaml
+++ b/tests/mock_data/calicoctl/explicit_peering/selectors/input.yaml
@@ -37,6 +37,7 @@ metadata:
 spec:
   bgp:
     ipv4Address: 10.192.0.2/16
+    ipv6Address: fd5f::2/96
 
 ---
 
@@ -49,6 +50,7 @@ metadata:
 spec:
   bgp:
     ipv4Address: 10.192.0.3/16
+    ipv6Address: fd5f::3/96
 
 ---
 
@@ -61,3 +63,4 @@ metadata:
 spec:
   bgp:
     ipv4Address: 10.192.0.4/16
+    ipv6Address: fd5f::4/96


### PR DESCRIPTION
Note, this is interdependent with https://github.com/projectcalico/node/pull/71, which has associated BIRD6 template changes.  The node PR needs to be merged first, then the https://github.com/projectcalico/confd/pull/155/commits/86f60ae0f93d4cf160a0a3855f6add2407f093b8 commit should be removed from this PR, and then this PR can be merged.