### PR TITLE
improve resilience of config generation when kube-apiclient is not available

### DIFF
--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -173,8 +173,15 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 	}
 
 	// Create and start route generator.
-	if rg := NewRouteGenerator(c); rg != nil {
-		rg.Start()
+	routes := os.Getenv(envStaticRoutes)
+	if len(routes) > 0 {
+		if rg, err := NewRouteGenerator(c); err != nil {
+			log.WithError(err).Fatal("Failed to start route generator")
+		} else {
+			rg.Start(routes)
+		}
+	} else {
+		log.Info("CALICO_STATIC_ROUTES not specified, no service ips will be advertised")
 	}
 	return c, nil
 }

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -173,15 +173,9 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 	}
 
 	// Create and start route generator.
-	rg, err := NewRouteGenerator(c)
-	if err != nil {
-		log.WithError(err).Fatal("Failed to create route generator")
+	if rg := NewRouteGenerator(c); rg != nil {
+		rg.Start()
 	}
-	err = rg.Start()
-	if err != nil {
-		log.WithError(err).Fatal("Failed to start route generator")
-	}
-
 	return c, nil
 }
 


### PR DESCRIPTION
This change essentially internalizes all error handling in the `routeGenerator`. If an error occurs in `NewRouteGenerator` (which are all kubeclient initialization related), it will simply return `nil` which the `client` will check for before calling `Start`. 