### PR TITLE
service ip advertisement: UX enhancements

### DIFF
--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -173,7 +173,7 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 	}
 
 	// Create and start route generator.
-	routes := os.Getenv(envStaticRoutes)
+	routes := os.Getenv(envAdvertiseClusterIPs)
 	if len(routes) > 0 {
 		if rg, err := NewRouteGenerator(c); err != nil {
 			log.WithError(err).Fatal("Failed to start route generator")
@@ -181,7 +181,7 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 			rg.Start(routes)
 		}
 	} else {
-		log.Info("CALICO_STATIC_ROUTES not specified, no service ips will be advertised")
+		log.Info(envAdvertiseClusterIPs + " not specified, no cluster ips will be advertised")
 	}
 	return c, nil
 }

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -97,17 +97,12 @@ func (rg *routeGenerator) Start(routeString string) {
 	// parse routeString
 	for _, route := range strings.Split(routeString, ",") {
 		cidr := strings.TrimSpace(route)
-		if len(cidr) == 0 {
-			// skip empty string
+		// consider anything else as cidr
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			log.WithField("cidr", cidr).WithError(err).Warn("Start: failed to parse cidr, passing")
 			continue
-		} else {
-			// consider anything else as cidr
-			if _, _, err := net.ParseCIDR(cidr); err != nil {
-				log.WithField("cidr", cidr).WithError(err).Warn("Start: failed to parse cidr, passing")
-				continue
-			}
-			cidrs = append(cidrs, cidr)
 		}
+		cidrs = append(cidrs, cidr)
 	}
 
 	// affix cidrs to the route map
@@ -125,11 +120,6 @@ func (rg *routeGenerator) Start(routeString string) {
 
 // getServiceForEndpoints retrieves the corresponding svc for the given ep
 func (rg *routeGenerator) getServiceForEndpoints(ep *v1.Endpoints) (*v1.Service, string) {
-	// do nothing if the endpoints have no subsets in it
-	if len(ep.Subsets) == 0 {
-		log.WithField("ep", ep.Name).Debug("getServiceForEndpoints: ep has no subsets, passing...")
-		return nil, ""
-	}
 	// get key
 	key, err := cache.MetaNamespaceKeyFunc(ep)
 	if err != nil {
@@ -142,7 +132,7 @@ func (rg *routeGenerator) getServiceForEndpoints(ep *v1.Endpoints) (*v1.Service,
 		log.WithField("key", key).WithError(err).Warn("getServiceForEndpoints: error on retrieving service for key, passing")
 		return nil, key
 	} else if !exists {
-		log.WithField("key", key).Warn("getServiceForEndpoints: service for key not found, passing")
+		log.WithField("key", key).Debug("getServiceForEndpoints: service for key not found, passing")
 		return nil, key
 	}
 	return svcIface.(*v1.Service), key
@@ -150,26 +140,6 @@ func (rg *routeGenerator) getServiceForEndpoints(ep *v1.Endpoints) (*v1.Service,
 
 // getEndpointsForService retrieves the corresponding ep for the given svc
 func (rg *routeGenerator) getEndpointsForService(svc *v1.Service) (*v1.Endpoints, string) {
-	// do nothing if the svc is not
-	if (svc.Spec.Type != v1.ServiceTypeClusterIP) &&
-		(svc.Spec.Type != v1.ServiceTypeNodePort) &&
-		(svc.Spec.Type != v1.ServiceTypeLoadBalancer) {
-		log.WithFields(log.Fields{
-			"svc":  svc.Name,
-			"type": svc.Spec.Type,
-		}).Debug("getEndpointForService: svc is not a valid type, passing...")
-		return nil, ""
-	}
-	// also do nothing if the clusterIP is empty or None
-	if len(svc.Spec.ClusterIP) > 0 &&
-		svc.Spec.ClusterIP != "None" {
-		log.WithFields(log.Fields{
-			"svc":       svc.Name,
-			"clusterIP": svc.Spec.ClusterIP,
-		}).Debug("getEndpointsForService: svc clusterIP is not valid, passing...")
-		return nil, ""
-	}
-
 	// get key
 	key, err := cache.MetaNamespaceKeyFunc(svc)
 	if err != nil {
@@ -182,7 +152,7 @@ func (rg *routeGenerator) getEndpointsForService(svc *v1.Service) (*v1.Endpoints
 		log.WithField("key", key).WithError(err).Warn("getEndpointsForService: error on retrieving endpoint for key, passing")
 		return nil, key
 	} else if !exists {
-		log.WithField("key", key).Warn("getEndpointsForService: service for endpoint not found, passing")
+		log.WithField("key", key).Debug("getEndpointsForService: service for endpoint not found, passing")
 		return nil, key
 	}
 	return epIface.(*v1.Endpoints), key
@@ -227,6 +197,16 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 // advertiseThisService returns true if this service should be advertised on this node,
 // false otherwise.
 func (rg *routeGenerator) advertiseThisService(svc *v1.Service, ep *v1.Endpoints) bool {
+	// do nothing if the svc is not a relevant type
+	if (svc.Spec.Type != v1.ServiceTypeClusterIP) && (svc.Spec.Type != v1.ServiceTypeNodePort) && (svc.Spec.Type != v1.ServiceTypeLoadBalancer) {
+		return false
+	}
+
+	// also do nothing if the clusterIP is empty or None
+	if len(svc.Spec.ClusterIP) > 0 && svc.Spec.ClusterIP != "None" {
+		return false
+	}
+
 	// always set if externalTrafficPolicy != local
 	if svc.Spec.ExternalTrafficPolicy != v1.ServiceExternalTrafficPolicyTypeLocal {
 		return true

--- a/tests/compiled_templates/etcdv3/mesh/static-routes/bird_aggr.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/static-routes/bird_aggr.cfg
@@ -9,7 +9,6 @@ protocol static {
    route 192.168.221.64/26 blackhole;
    # Static routes.
    route 10.65.1.0/24 blackhole;
-   route 10.66.1.0/24 blackhole;
 }
 
 

--- a/tests/compiled_templates/etcdv3/mesh/static-routes/bird_ipam.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/static-routes/bird_ipam.cfg
@@ -4,7 +4,6 @@ filter calico_export_to_bgp_peers {
 
   # Export static routes.
   if ( net = 10.65.1.0/24 ) then { accept; }
-  if ( net = 10.66.1.0/24 ) then { accept; }
 
   if ( net ~ 192.168.0.0/16 ) then {
     accept;
@@ -18,7 +17,6 @@ filter calico_kernel_programming {
 
   # Don't program static routes into kernel.
   if ( net = 10.65.1.0/24 ) then { reject; }
-  if ( net = 10.66.1.0/24 ) then { reject; }
 
   if ( net ~ 192.168.0.0/16 ) then {
 

--- a/tests/test_suite_common.sh
+++ b/tests/test_suite_common.sh
@@ -55,7 +55,7 @@ run_extra_test() {
 }
 
 test_static_routes() {
-    export CALICO_ADVERTISE_CLUSTER_IPS=10.65.1.0/24,10.66.1.0/24
+    export CALICO_ADVERTISE_CLUSTER_IPS=10.65.1.0/24
     run_individual_test_oneshot 'mesh/static-routes'
     export -n CALICO_ADVERTISE_CLUSTER_IPS
     unset CALICO_ADVERTISE_CLUSTER_IPS

--- a/tests/test_suite_common.sh
+++ b/tests/test_suite_common.sh
@@ -55,10 +55,10 @@ run_extra_test() {
 }
 
 test_static_routes() {
-    export CALICO_STATIC_ROUTES=10.65.1.0/24,10.66.1.0/24
+    export CALICO_ADVERTISE_CLUSTER_IPS=10.65.1.0/24,10.66.1.0/24
     run_individual_test_oneshot 'mesh/static-routes'
-    export -n CALICO_STATIC_ROUTES
-    unset CALICO_STATIC_ROUTES
+    export -n CALICO_ADVERTISE_CLUSTER_IPS
+    unset CALICO_ADVERTISE_CLUSTER_IPS
 }
 
 test_node_deletion() {


### PR DESCRIPTION
- use `CALICO_ADVERTISE_CLUSTER_IPS` instead of `CALICO_STATIC_ROUTES` to trigger service ip advertisement
- add logic to filter irrelevant services and endpoints