### PR TITLE
Trigger WatchPrefixes when we get new route updates

### DIFF
--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -711,6 +711,11 @@ func (c *client) OnUpdates(updates []api.Update) {
 		c.updateCache(u.UpdateType, &u.KVPair)
 	}
 
+	// Notify watcher thread that we've received new updates.
+	c.onNewUpdates()
+}
+
+func (c *client) onNewUpdates() {
 	if c.synced {
 		// Wake up the watchers to let them know there may be some updates of interest.  We only
 		// need to do this once we're synced because until that point all of the Watcher threads
@@ -894,6 +899,7 @@ func (c *client) AddRejectCIDRs(cidrs []string) {
 		c.cache[k] = cidr
 		c.keyUpdated(k)
 	}
+	c.onNewUpdates()
 }
 
 // DeleteRejectCIDRs removes the config to reject routes within the given CIDRs.
@@ -906,6 +912,7 @@ func (c *client) DeleteRejectCIDRs(cidrs []string) {
 		delete(c.cache, k)
 		c.keyUpdated(k)
 	}
+	c.onNewUpdates()
 }
 
 // AddStaticRoutes adds the given CIDRs as static routes to be advertised from this node.
@@ -918,6 +925,7 @@ func (c *client) AddStaticRoutes(cidrs []string) {
 		c.cache[k] = cidr
 		c.keyUpdated(k)
 	}
+	c.onNewUpdates()
 }
 
 // DeleteStaticRoutes withdraws the given CIDRs from the set of static routes advertised
@@ -931,4 +939,5 @@ func (c *client) DeleteStaticRoutes(cidrs []string) {
 		delete(c.cache, k)
 		c.keyUpdated(k)
 	}
+	c.onNewUpdates()
 }

--- a/pkg/backends/calico/routes_test.go
+++ b/pkg/backends/calico/routes_test.go
@@ -1,6 +1,8 @@
 package calico
 
 import (
+	"sync"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -40,9 +42,11 @@ var _ = Describe("RouteGenerator", func() {
 			epIndexer:   cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
 			svcRouteMap: make(map[string]string),
 			client: &client{
-				cache: make(map[string]string),
+				cache:  make(map[string]string),
+				synced: true,
 			},
 		}
+		rg.client.watcherCond = sync.NewCond(&rg.client.cacheLock)
 	})
 	Describe("getServiceForEndpoints", func() {
 		It("should get corresponding service for endpoints", func() {
@@ -109,12 +113,15 @@ var _ = Describe("RouteGenerator", func() {
 		Context("onSvc[Add|Delete]", func() {
 			It("should add the service's clusterIP into the svcRouteMap", func() {
 				// add
+				initRevision := rg.client.cacheRevision
 				rg.onSvcAdd(svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// delete
 				rg.onSvcDelete(svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
@@ -122,13 +129,16 @@ var _ = Describe("RouteGenerator", func() {
 
 		Context("onSvcUpdate", func() {
 			It("should add the service's clusterIP into the svcRouteMap and then remove it for unsupported service type", func() {
+				initRevision := rg.client.cacheRevision
 				rg.onSvcUpdate(nil, svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// set to unsupport service type
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				rg.onSvcUpdate(nil, svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
@@ -137,12 +147,15 @@ var _ = Describe("RouteGenerator", func() {
 		Context("onEp[Add|Delete]", func() {
 			It("should add the service's clusterIP into the svcRouteMap", func() {
 				// add
+				initRevision := rg.client.cacheRevision
 				rg.onEPAdd(ep)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// delete
 				rg.onEPDelete(ep)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
@@ -150,13 +163,16 @@ var _ = Describe("RouteGenerator", func() {
 
 		Context("onEpDelete", func() {
 			It("should add the service's clusterIP into the svcRouteMap and then remove it for unsupported service type", func() {
+				initRevision := rg.client.cacheRevision
 				rg.onEPUpdate(nil, ep)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
 				Expect(rg.svcRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// set to unsupport service type
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				rg.onEPUpdate(nil, ep)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})


### PR DESCRIPTION
I think we were missing some logic to "wake up" the template generation code when routes change.

We must have been relying on other updates coming in and triggering this.