### PR TITLE
Fix race condition for BGP peers vs BGPConfiguration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ tmp/
 vendor
 .go-pkg-cache
 tests/logs/
-/report/calico_backend_suite.xml
+/report/*

--- a/tests/compiled_templates/etcdv3/explicit_peering/route_reflector/bird.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/route_reflector/bird.cfg
@@ -35,7 +35,7 @@ protocol direct {
 template bgp bgp_template {
   debug { states };
   description "Connection to BGP peer";
-  local as 64512;
+  local as 64532;
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream
@@ -61,6 +61,22 @@ template bgp bgp_template {
 # ------------- Node-specific peers -------------
 
 
+
+
+# For peer /host/kube-master/peer_v4/10.192.0.3
+protocol bgp Node_10_192_0_3 from bgp_template {
+  neighbor 10.192.0.3 as 64532;
+  rr client;
+  rr cluster id 10.0.0.1;
+}
+
+
+# For peer /host/kube-master/peer_v4/10.192.0.4
+protocol bgp Node_10_192_0_4 from bgp_template {
+  neighbor 10.192.0.4 as 64532;
+  rr client;
+  rr cluster id 10.0.0.1;
+}
 
 
 # For peer /host/kube-master/peer_v4/172.19.4.87

--- a/tests/compiled_templates/etcdv3/explicit_peering/route_reflector/bird6.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/route_reflector/bird6.cfg
@@ -35,7 +35,7 @@ protocol direct {
 template bgp bgp_template {
   debug { states };
   description "Connection to BGP peer";
-  local as 64512;
+  local as 64532;
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream

--- a/tests/compiled_templates/kubernetes/explicit_peering/route_reflector/bird.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/route_reflector/bird.cfg
@@ -35,7 +35,7 @@ protocol direct {
 template bgp bgp_template {
   debug { states };
   description "Connection to BGP peer";
-  local as 64512;
+  local as 64532;
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream
@@ -61,6 +61,22 @@ template bgp bgp_template {
 # ------------- Node-specific peers -------------
 
 
+
+
+# For peer /host/kube-master/peer_v4/10.192.0.3
+protocol bgp Node_10_192_0_3 from bgp_template {
+  neighbor 10.192.0.3 as 64532;
+  rr client;
+  rr cluster id 10.0.0.1;
+}
+
+
+# For peer /host/kube-master/peer_v4/10.192.0.4
+protocol bgp Node_10_192_0_4 from bgp_template {
+  neighbor 10.192.0.4 as 64532;
+  rr client;
+  rr cluster id 10.0.0.1;
+}
 
 
 # For peer /host/kube-master/peer_v4/172.19.4.87

--- a/tests/compiled_templates/kubernetes/explicit_peering/route_reflector/bird6.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/route_reflector/bird6.cfg
@@ -35,7 +35,7 @@ protocol direct {
 template bgp bgp_template {
   debug { states };
   description "Connection to BGP peer";
-  local as 64512;
+  local as 64532;
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream

--- a/tests/mock_data/calicoctl/explicit_peering/route_reflector/delete.yaml
+++ b/tests/mock_data/calicoctl/explicit_peering/route_reflector/delete.yaml
@@ -24,3 +24,10 @@ kind: BGPPeer
 apiVersion: projectcalico.org/v3
 metadata:
   name: bgppeer-v6
+
+---
+
+kind: BGPPeer
+apiVersion: projectcalico.org/v3
+metadata:
+  name: bgppeer-other-nodes

--- a/tests/mock_data/calicoctl/explicit_peering/route_reflector/input.yaml
+++ b/tests/mock_data/calicoctl/explicit_peering/route_reflector/input.yaml
@@ -3,10 +3,13 @@ apiVersion: projectcalico.org/v3
 metadata:
   name: default
 spec:
+  asNumber: 64532
   nodeToNodeMeshEnabled: false
 
 ---
 
+# This BGPPeer peers the RR node (kube-master) with an explicit
+# external peer.
 kind: BGPPeer
 apiVersion: projectcalico.org/v3
 metadata:
@@ -18,6 +21,8 @@ spec:
 
 ---
 
+# This BGPPeer peers the RR node (kube-master) with an explicit
+# external v6 peer.
 kind: BGPPeer
 apiVersion: projectcalico.org/v3
 metadata:
@@ -26,6 +31,18 @@ spec:
   peerIP: ac13::57
   asNumber: 64533
   nodeSelector: has(routeReflector)
+
+---
+
+# This BGPPeer peers the RR node (kube-master) with the other
+# non-RR nodes in the cluster (kube-node-1, kube-node-2).
+kind: BGPPeer
+apiVersion: projectcalico.org/v3
+metadata:
+  name: bgppeer-other-nodes
+spec:
+  nodeSelector: has(routeReflector)
+  peerSelector: '!has(routeReflector)'
 
 ---
 
@@ -71,4 +88,3 @@ metadata:
 spec:
   bgp:
     ipv4Address: 10.192.0.4/16
-


### PR DESCRIPTION
Reproduce and fix https://github.com/projectcalico/calico/issues/2373

Problem here is that we're not triggering a recalculation of peers when Global / per-Node BGPConfiguration resources change.

That means if we compute a BGP peer during sync, but don't receive the BGPConfiguration until afterwards, we won't update those computed BGP peers.