### PR TITLE
Only update peers if there was a significant change in nodes

### DIFF
--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -795,7 +795,7 @@ func (c *client) updateCache(updateType api.UpdateType, kvp *model.KVPair) bool 
 			return false
 		}
 		newValue := string(value)
-		if c.cache[k] != newValue {
+		if currentValue, isSet := c.cache[k]; !isSet || currentValue != newValue {
 			entryUpdated = true
 			c.cache[k] = newValue
 		}

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -701,7 +701,8 @@ func (c *client) OnUpdates(updates []api.Update) {
 					log.Warning("Bad value for Node resource")
 					continue
 				}
-				if !reflect.DeepEqual(c.nodeLabels[v3key.Name], v3res.Labels) {
+				existingLabels, isSet := c.nodeLabels[v3key.Name]
+				if !isSet || !reflect.DeepEqual(existingLabels, v3res.Labels) {
 					c.nodeLabels[v3key.Name] = v3res.Labels
 					needUpdatePeersV1 = true
 				}


### PR DESCRIPTION
This PR updates confd to only recompute BGP peers when node updates include meaninful changes compared to the cached values.

A little backstory for the motivation behind this PR.

We run some moderated size kubernetes clusters on our infrastructure and we were running Calico 3.0.5 without any problems. They run with Typha enable and using kubernetes as the data storage. Also, we disable node-to-node mesh and control the mesh ourselves by using the BGPPeers CRD with https://github.com/tsuru/remesher.

We decided to upgrade our development cluster to Calico 3.6.1. This cluster usually has around 63 nodes and we have around 2500 bgppeers entries:

```
$ kubectl get bgppeers.crd.projectcalico.org  | wc -l
    2622
$ kubectl get nodes | wc -l
      64
```

After migrating to 3.6.1 we saw a huge increase in CPU usage on all calico-node pods. This high cpu usage was tracked to the `calico-node -confd` process:

<img width="1267" alt="confd-img1" src="https://user-images.githubusercontent.com/11041/55638470-a4ed2e00-579d-11e9-9840-88b4471d789f.png">

We went on to enable debug logging on the confd process and found out that it was constantly trying to regenerate the rendered templates even though there wasn't any changes to them. We also found out that regenerating the peers was triggered by node update events:
```
3d5210796bba[22368]: 2019-04-05 14:54:16.519 [DEBUG][28749] client.go 623: Update: api.Update{KVPair:model.KVPair{Key:model.ResourceKey{Name:"10.224.141.40", Namespace:"", Kind:"Node"}, Value:(*v3.Node)(0xc000388000), Revision:"152509306", UID:(*types.UID)(nil), TTL:0}, UpdateType:0x2}
...
3d5210796bba[22368]: 2019-04-05 14:54:16.524 [DEBUG][28749] client.go 721: Recompute BGP peerings
...
3d5210796bba[22368]: 2019-04-05 14:54:19.909 [DEBUG][28749] client.go 623: Update: api.Update{KVPair:model.KVPair{Key:model.ResourceKey{Name:"10.224.141.110", Namespace:"", Kind:"Node"}, Value:(*v3.Node)(0xc000388140), Revision:"152509307", UID:(*types.UID)(nil), TTL:0}, UpdateType:0x2}
...
3d5210796bba[22368]: 2019-04-05 14:54:19.911 [DEBUG][28749] client.go 721: Recompute BGP peerings 
```

Node update events on kubernetes are tricky, they trigger roughly every 10 seconds for every node due to `kubelet` updating the node heartbeat statuses. This updates will then trigger confd to recompute all BGP peerings even though nothing meaninful has changed.

This PR changes `OnUpdates()` calls to first compare each node attribute to the existing value in the cache. Recomputing bgp peers is then only triggered if the cache was updated. We introduced this change on one of our nodes and the result for CPU usage was fantastic, it went back to the levels we had when running 3.0.5:

<img width="1267" alt="confd-img2" src="https://user-images.githubusercontent.com/11041/55638487-b0405980-579d-11e9-81cc-0cfbde18e093.png">

