### PR TITLE
Disable vxlanMode for ipv6 CI test.

### DIFF
--- a/tests/mock_data/calicoctl/mesh/ipip-off/delete.yaml
+++ b/tests/mock_data/calicoctl/mesh/ipip-off/delete.yaml
@@ -15,4 +15,5 @@ metadata:
 spec:
   cidr: 2002::/64
   ipipMode: Never
+  vxlanMode: Never
   natOutgoing: true

--- a/tests/mock_data/calicoctl/mesh/ipip-off/input.yaml
+++ b/tests/mock_data/calicoctl/mesh/ipip-off/input.yaml
@@ -58,4 +58,5 @@ metadata:
 spec:
   cidr: 2002::/64
   ipipMode: Never
+  vxlanMode: Never
   natOutgoing: true


### PR DESCRIPTION
This is to fix validation failure `error with field IPpool.VXLANMode = '' (VXLANMode other than 'Never' is not supported on an IPv6 IP pool)`