### PR TITLE
Take latest master version of typha.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7c8278361496d48f1d7b8da73859d5ecccedf80041ce7152f5d3be7a7a0aacbb
-updated: 2019-07-06T04:14:46.648059617Z
+hash: e8d4616edb2cbffb3dcc38c5ea1ea5dbb216fbce090cc4f8bed09d95cb45e4c6
+updated: 2019-07-17T16:20:09.073893561-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -14,7 +14,7 @@ imports:
   - autorest/azure
   - autorest/date
 - name: github.com/beorn7/perks
-  version: 4b2b341e8d7715fae06375aa633dbb6e91b3fb46
+  version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/BurntSushi/toml
@@ -91,7 +91,7 @@ imports:
   subpackages:
   - simplelru
 - name: github.com/hpcloud/tail
-  version: a30252cb686a21eb2d0b98132633053ec2f7f1e5
+  version: a1dbeea552b7c8df4b542c66073e393de198a800
   subpackages:
   - ratelimiter
   - util
@@ -108,7 +108,7 @@ imports:
 - name: github.com/leodido/go-urn
   version: a67a23e1c1af3c66528573bb86a87246477277c1
 - name: github.com/matttproud/golang_protobuf_extensions
-  version: c182affec369e30f25d3eb8cd8a478dee585ae7d
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/modern-go/concurrent
@@ -162,7 +162,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 714ce2bcad0cc2fc765ee63370904d7c2c473af4
+  version: e3e8f00211f91ffce4087eada516076549cbfb75
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -198,7 +198,7 @@ imports:
   - lib/validator/v3
   - lib/watch
 - name: github.com/projectcalico/typha
-  version: 9446918cdcabadf48f10c5a3115a92b3e667bc50
+  version: cbe2224d1228911293b7c4ab8fde79d49c4d85fc
   subpackages:
   - pkg/syncclient
   - pkg/syncproto
@@ -209,7 +209,7 @@ imports:
   - prometheus
   - prometheus/internal
 - name: github.com/prometheus/client_model
-  version: fd36f4220a901265f90734c3183c5f0c91daa0b8
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
@@ -284,7 +284,7 @@ imports:
   subpackages:
   - rate
 - name: google.golang.org/appengine
-  version: 54a98f90d1c46b7731eb8fb305d2a321c30ef610
+  version: 4a4468ece617fc8205e99368fa2200e9d1fad421
   subpackages:
   - internal
   - internal/app_identity
@@ -320,10 +320,10 @@ imports:
   - status
   - tap
   - transport
-- name: gopkg.in/fsnotify.v1
-  version: 7be54206639f256967dd82fa767397ba5f8f48f5
+- name: gopkg.in/fsnotify/fsnotify.v1
+  version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: gopkg.in/go-playground/validator.v9
-  version: 46b4b1e301c24cac870ffcb4ba5c8a703d1ef475
+  version: b199fa0642d29caca62b6a99d65cc981ba5edc3b
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/tomb.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,7 +20,7 @@ import:
 - package: github.com/sirupsen/logrus
   version: v1.0.4
 - package: github.com/projectcalico/typha
-  version: 9446918cdcabadf48f10c5a3115a92b3e667bc50
+  version: cbe2224d1228911293b7c4ab8fde79d49c4d85fc
 testImports:
 - package: github.com/onsi/ginkgo
 - package: github.com/onsi/gomega


### PR DESCRIPTION
Only updated the typha version in `glyde.yaml` to match the latest master. The `glide.lock` file was outdated already and most changes are simply made by doing `glide update; glide install`

No release notes required for this one.

Related to:
projectcalico/libcalico-go#1106
projectcalico/libcalico-go#1108
projectcalico/calico#2728