### PR TITLE
Store more ippool info into /tmp/tunl-ip to trigger tunnel-address allocation

### DIFF
--- a/etc/calico/confd/templates/tunl-ip.template
+++ b/etc/calico/confd/templates/tunl-ip.template
@@ -3,6 +3,6 @@ address allocation code whenever an IP pool changes.
  
 {{range ls "/pool"}}{{$data := json (getv (printf "/pool/%s" .))}}
   {{- if or $data.ipip $data.vxlan_mode}}
-    {{- if not $data.disabled}}{{$data.cidr}}{{end}}
+    {{- if not $data.disabled}}{{$data}}{{end}}
   {{- end}}
 {{end}}


### PR DESCRIPTION
Currently, changes of ippool settings from ipip to vxlan will not take into effect until after the node is rebooted.

This is because the contents of `/tmp/tunl-ip` on the nodes are stale. The only thing that is written here is the cidr, which does not change when you change from ipip -> vxlan. Therefore the listener that watches the file will not act on it (see `tunl-ip.toml`)

I have chosen to put the whole object into the file, rather than just adding `VXLANMode` and `IPIPMode` for two reasons:
1 This better matches the description already present in the file
2 If we add mode ippool options in the future, they will be picked up automatically.

I have verified that this fix resolves the problem. After an Ippool change, the file looks like this:
```
(output of `root@rene-kadm-ms:/# more /tmp/tunl-ip`)
We must dump all pool data to this file to trigger a re-run of the tunnel
address allocation code whenever an IP pool changes.
 
map[masquerade:true ipam:true disabled:false cidr:192.168.0.0/16 ipip:tunl0 ipip_mode:always vxlan_mode:]

```

The image can be found here: `image: rdtigera/node-ippool-fix`

# Release note 

```release-note
fix that enabling VXLAN required restarting the calico/node pod
```