### PR TITLE
Preserve the next hop on BGP advertisements

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -76,6 +76,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address {{$node_ip}};  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/etc/calico/confd/templates/bird6.cfg.template
+++ b/etc/calico/confd/templates/bird6.cfg.template
@@ -76,6 +76,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address {{$node_ip6}};  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/explicit_peering/global/bird.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/global/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/explicit_peering/route_reflector/bird.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/route_reflector/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/explicit_peering/route_reflector/bird6.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/route_reflector/bird6.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address fe0a::2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/explicit_peering/selectors/bird.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/selectors/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/explicit_peering/selectors/bird6.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/selectors/bird6.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address fd5f::2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/explicit_peering/specific_node/bird.cfg
+++ b/tests/compiled_templates/etcdv3/explicit_peering/specific_node/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/mesh/hash/bird.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/hash/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/mesh/ipip-always/bird.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/ipip-always/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/mesh/ipip-cross-subnet/bird.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/ipip-cross-subnet/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/mesh/ipip-off/bird.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/ipip-off/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/mesh/ipip-off/bird6.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/ipip-off/bird6.cfg
@@ -42,6 +42,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 2001::103;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/mesh/static-routes/bird.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/static-routes/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/etcdv3/mesh/vxlan-always/bird.cfg
+++ b/tests/compiled_templates/etcdv3/mesh/vxlan-always/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/explicit_peering/global/bird.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/global/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/explicit_peering/route_reflector/bird.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/route_reflector/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/explicit_peering/route_reflector/bird6.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/route_reflector/bird6.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address fe0a::2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/explicit_peering/selectors/bird.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/selectors/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/explicit_peering/selectors/bird6.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/selectors/bird6.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address fd5f::2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/explicit_peering/specific_node/bird.cfg
+++ b/tests/compiled_templates/kubernetes/explicit_peering/specific_node/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/mesh/ipip-always/bird.cfg
+++ b/tests/compiled_templates/kubernetes/mesh/ipip-always/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/mesh/ipip-cross-subnet/bird.cfg
+++ b/tests/compiled_templates/kubernetes/mesh/ipip-cross-subnet/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/mesh/ipip-off/bird.cfg
+++ b/tests/compiled_templates/kubernetes/mesh/ipip-off/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/mesh/ipip-off/bird6.cfg
+++ b/tests/compiled_templates/kubernetes/mesh/ipip-off/bird6.cfg
@@ -42,6 +42,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 2001::103;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;

--- a/tests/compiled_templates/kubernetes/mesh/vxlan-always/bird.cfg
+++ b/tests/compiled_templates/kubernetes/mesh/vxlan-always/bird.cfg
@@ -43,6 +43,7 @@ template bgp bgp_template {
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
   source address 10.192.0.2;  # The local address we use for the TCP connection
   add paths on;
+  next hop keep;     # Preserve the next hop in advertisements
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
   connect retry time 5;


### PR DESCRIPTION
When #206 was merged to fix #199, this had the unintended consequence of also causing nodes not acting as route reflectors to re-advertise static routes learnt via node-to-node mesh. This meant all nodes were receiving traffic for services with externalTrafficPolicy: Local even if they were not running an endpoint for the service.

This change ensures that the correct next hop is advertised to any bgp peers.

This also has the knock on affect of advertising the node IP as the next hop in pod network advertisements, this is quite different to the current behavior **and it is quite possible that, for reasons I don't currently understand this is undesirable**. At first glance this actually seems desirable as it will allow traffic to always be directed to the correct node as opposed to hopping around the cluster, hence this PR.
Hopefully someone with more knowledge of the project will be able to comment on the wider repercussions and intentions here.
A possible compromise could be to put this config only under global/node-specific peers (i.e. not in the routing mesh).

If this behavior is undesired, I have also created another branch which more directly addresses the behavior change introduced in #199 here: https://github.com/thomseddon/confd/commit/9c91ca5b982975adbb6f40991720b355ed46be92 - this means that on RRs will re-advertise service addresses, but without the fix in this PR, the BGP peer will still always receive a next-hop of the advertising node as opposed to the node running the endpoint.

