### PR TITLE
Advertise Whitelisted Service External IP's

### DIFF
--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -178,10 +178,10 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 	// Create and start route generator.
 	clusterCIDR := os.Getenv(envAdvertiseClusterIPs)
 	if len(clusterCIDR) > 0 {
-		if rg, err := NewRouteGenerator(c, clusterCIDR); err != nil {
+		if c.rg, err = NewRouteGenerator(c, clusterCIDR); err != nil {
 			log.WithError(err).Fatal("Failed to start route generator")
 		} else {
-			rg.Start()
+			c.rg.Start()
 		}
 	} else {
 		log.Info(envAdvertiseClusterIPs + " not specified, no cluster ips will be advertised")
@@ -255,6 +255,9 @@ type client struct {
 	nodeV1Processor watchersyncer.SyncerUpdateProcessor
 	nodeLabels      map[string]map[string]string
 	bgpPeers        map[string]*apiv3.BGPPeer
+
+	// The route generator
+	rg *routeGenerator
 
 	// Readiness signals for individual data sources.
 	syncerReady, rgReady bool

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -676,8 +676,13 @@ func (c *client) OnUpdates(updates []api.Update) {
 
 				if cfgKey.Name == "svc_external_ips" {
 					log.Debugf("Global serviceExternalIPs changed.")
-					c.updateExternalIPNets()
-					c.rg.onBGPConfigurationUpdate()
+					if u.UpdateType == api.UpdateTypeKVDeleted {
+						c.rg.onBGPConfigurationUpdate(nil)
+					} else {
+						v1Str := u.Value.(string)
+						nets := parseExternalIPNets(v1Str)
+						c.rg.onBGPConfigurationUpdate(nets)
+					}
 				}
 			}
 

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -115,7 +115,6 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 		nodeMeshEnabled:   nodeMeshEnabled,
 		nodeLabels:        make(map[string]map[string]string),
 		bgpPeers:          make(map[string]*apiv3.BGPPeer),
-		externalIPNets:    make([]*net.IPNet, 0),
 	}
 	for k, v := range globalDefaults {
 		c.cache[k] = v
@@ -283,9 +282,6 @@ type client struct {
 	// Whether the node to node mesh is enabled or not.
 	nodeMeshEnabled bool
 
-	// The whitelist of External IP CIDR Networks to advertise
-	externalIPNets []*net.IPNet
-
 	// This node's log level key.
 	nodeLogKey string
 }
@@ -355,8 +351,7 @@ func (c *client) OnInSync(source string) {
 	}
 }
 
-func (c *client) updateExternalIPNets() {
-	v1Str, _ := model.KeyToDefaultPath(model.GlobalBGPConfigKey{Name: "svc_external_ips"})
+func parseExternalIPNets(v1Str string) []*net.IPNet {
 	ipCIDRs := strings.Split(v1Str, ",")
 
 	ipNets := make([]*net.IPNet, 0)
@@ -370,7 +365,7 @@ func (c *client) updateExternalIPNets() {
 		ipNets = append(ipNets, ipNet)
 	}
 
-	c.externalIPNets = ipNets
+	return ipNets
 }
 
 type bgpPeer struct {

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -100,9 +100,6 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 		nodeMeshEnabled = *cfg.Spec.NodeToNodeMeshEnabled
 	}
 
-	// Parse the whitelisted service External IP CIDRs from the bgpconfig spec.
-	externalIPCIDRs := parseExternalIPCIDRs(cfg.Spec.ServiceExternalIPs)
-
 	// We know the v2 client implements the backendClientAccessor interface.  Use it to
 	// get the backend client.
 	bc := cc.(backendClientAccessor).Backend()
@@ -191,25 +188,6 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 		c.OnInSync(SourceRouteGenerator)
 	}
 	return c, nil
-}
-
-// parseExternalIPCIDRs parses the SvcExternalIPBlock from a bgpconfiguration
-// into net.IPNet objects.
-func parseExternalIPCIDRs(IPBlocks []apiv3.SvcExternalIPBlock) []*net.IPNet {
-
-	ipNets := make([]*net.IPNet, 0)
-	for _, block := range IPBlocks {
-		_, ipNet, err := net.ParseCIDR(block.CIDR)
-		if err != nil {
-			log.Errorf("Failed to parse External IP CIDR: %s: %v", block, err)
-			continue
-		}
-
-		ipNets = append(ipNets, ipNet)
-	}
-
-	return ipNets
-
 }
 
 var ErrServiceNotReady = errors.New("Kubernetes service missing IP or port.")

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -115,7 +115,7 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 		nodeMeshEnabled:   nodeMeshEnabled,
 		nodeLabels:        make(map[string]map[string]string),
 		bgpPeers:          make(map[string]*apiv3.BGPPeer),
-		externalIPCIDRs:   make([]*net.IPNet, 0),
+		externalIPNets:    make([]*net.IPNet, 0),
 	}
 	for k, v := range globalDefaults {
 		c.cache[k] = v
@@ -280,8 +280,8 @@ type client struct {
 	// Whether the node to node mesh is enabled or not.
 	nodeMeshEnabled bool
 
-	// The whitelist of External IP CIDRs to advertise
-	externalIPCIDRs []*net.IPNet
+	// The whitelist of External IP CIDR Networks to advertise
+	externalIPNets []*net.IPNet
 
 	// This node's log level key.
 	nodeLogKey string

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -360,7 +360,7 @@ func (c *client) updateExternalIPNets() {
 	for _, CIDR := range ipCIDRs {
 		_, ipNet, err := net.ParseCIDR(CIDR)
 		if err != nil {
-			log.Errorf("Failed to parse External IP CIDR: %s: %v", CIDR, err)
+			log.WithError(err).Errorf("Failed to parse External IP CIDR: %s.", CIDR)
 			continue
 		}
 

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -682,6 +682,7 @@ func (c *client) OnUpdates(updates []api.Update) {
 				if cfgKey.Name == "svc_external_ips" {
 					log.Debugf("Global serviceExternalIPs changed.")
 					c.updateExternalIPNets()
+					c.rg.onBGPConfigurationUpdate()
 				}
 			}
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -231,7 +231,7 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 
 			// Advertise route if not already advertised
 			if _, ok := advertisedExternalRoutes[route]; !ok {
-				// TODO: advertise external IP route
+				rg.advertiseExternalRoute(key, route)
 			}
 
 		}
@@ -239,7 +239,7 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 		// Withdraw any routes we are advertising that are no longer External IPs
 		for route := range advertisedExternalRoutes {
 			if !contains(externalRoutes, route) {
-				// TODO: withdraw external IP route
+				rg.withdrawExternalRoute(key, route)
 			}
 		}
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -321,6 +321,14 @@ func (rg *routeGenerator) unsetRouteForSvc(obj interface{}) {
 	if route, exists := rg.svcClusterRouteMap[key]; exists {
 		rg.withdrawClusterRoute(key, route)
 	}
+
+	// Remove all External IP's
+	if rg.svcExternalRouteMap[key] != nil {
+		for route := range rg.svcExternalRouteMap[key] {
+			rg.withdrawExternalRoute(key, route)
+		}
+	}
+
 }
 
 // advertiseClusterRoute advertises a route for a service ClusterIP and caches it.

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -394,10 +394,10 @@ func (rg *routeGenerator) withdrawExternalRoute(key, route string) {
 
 	if rg.svcExternalRouteMap[key] != nil {
 		delete(rg.svcExternalRouteMap[key], route)
-	}
 
-	if len(rg.svcExternalRouteMap[key]) == 0 {
-		delete(rg.svcExternalRouteMap, key)
+		if len(rg.svcExternalRouteMap[key]) == 0 {
+			delete(rg.svcExternalRouteMap, key)
+		}
 	}
 }
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -335,6 +335,27 @@ func (rg *routeGenerator) withdrawClusterRoute(key, route string) {
 	delete(rg.svcClusterRouteMap, key)
 }
 
+// advertiseExternalRoute advertises a route for a service ExternalIP and
+// caches it.
+func (rg *routeGenerator) advertiseExternalRoute(key, route string) {
+	if rg.svcExternalRouteMap[key] == nil {
+		rg.svcExternalRouteMap[key] = make(map[string]bool)
+	}
+
+	rg.client.AddStaticRoutes([]string{route})
+	rg.svcExternalRouteMap[key][route] = true
+}
+
+// withdrawExternalRoute withdraws a route for a service ExternalIP and
+// removes it from the cache.
+func (rg *routeGenerator) withdrawExternalRoute(key, route string) {
+	rg.client.DeleteStaticRoutes([]string{route})
+
+	if rg.svcExternalRouteMap[key] != nil {
+		delete(rg.svcExternalRouteMap[key], route)
+	}
+}
+
 // onSvcAdd is called when a k8s service is created
 func (rg *routeGenerator) onSvcAdd(obj interface{}) {
 	svc, ok := obj.(*v1.Service)

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -218,7 +218,6 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 
 	// External IP's
 	if advertise {
-
 		advertisedExternalRoutes := rg.svcExternalRouteMap[key]
 		if advertisedExternalRoutes == nil {
 			advertisedExternalRoutes = make(map[string]bool)
@@ -248,7 +247,6 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 				rg.withdrawExternalRoute(key, route)
 			}
 		}
-
 	} else {
 		rg.unsetExternalRoutesForSvc(key)
 	}

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -418,8 +418,10 @@ func (rg *routeGenerator) withdrawRoute(key, route string) {
 	// "legitimately" being advertised twice from a node.
 	if rg.routeAdvertisementCount[route] == 1 {
 		rg.client.DeleteStaticRoutes([]string{route})
+		delete(rg.routeAdvertisementCount, route)
+	} else {
+		rg.routeAdvertisementCount[route]--
 	}
-	rg.routeAdvertisementCount[route]--
 
 	if rg.svcRouteMap[key] != nil {
 		delete(rg.svcRouteMap[key], route)

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -361,6 +361,9 @@ func (rg *routeGenerator) unsetExternalRoutesForSvc(key string) {
 		for route := range rg.svcExternalRouteMap[key] {
 			rg.withdrawExternalRoute(key, route)
 		}
+		if len(rg.svcExternalRouteMap[key]) == 0 {
+			delete(rg.svcExternalRouteMap, key)
+		}
 	}
 }
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -46,6 +46,7 @@ type routeGenerator struct {
 	svcInformer, epInformer cache.Controller
 	svcIndexer, epIndexer   cache.Indexer
 	svcClusterRouteMap      map[string]string
+	svcExternalRouteMap     map[string][]string
 	clusterCIDR             string
 }
 
@@ -68,10 +69,11 @@ func NewRouteGenerator(c *client, clusterCIDR string) (rg *routeGenerator, err e
 
 	// initialize empty route generator
 	rg = &routeGenerator{
-		client:             c,
-		nodeName:           nodename,
-		svcClusterRouteMap: make(map[string]string),
-		clusterCIDR:        clusterCIDR,
+		client:              c,
+		nodeName:            nodename,
+		svcClusterRouteMap:  make(map[string]string),
+		svcExternalRouteMap: make(map[string][]string),
+		clusterCIDR:         clusterCIDR,
 	}
 
 	// set up k8s client

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -195,6 +195,8 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 	// see if any endpoints are on this node and advertise if so
 	// else remove the route if it also already exists
 	rg.Lock()
+	defer rg.Unlock()
+
 	if rg.advertiseThisService(svc, ep) {
 		route := svc.Spec.ClusterIP + "/32"
 		if cur, exists := rg.svcClusterRouteMap[key]; !exists {
@@ -212,7 +214,6 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 		// We were advertising this route, but should no longer do so.
 		rg.withdrawRoute(key, cur)
 	}
-	rg.Unlock()
 }
 
 // advertiseThisService returns true if this service should be advertised on this node,

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -197,10 +197,10 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 	advertise := rg.advertiseThisService(svc, ep)
 	if advertise {
 		routes := rg.getAllRoutesForService(svc)
-		rg.advertiseRoutes(key, routes)
+		rg.setRoutesForKey(key, routes)
 	} else {
 		routes := rg.getAdvertisedRoutes(key)
-		rg.withdrawRoutes(key, routes)
+		rg.withdrawRoutesForKey(key, routes)
 	}
 
 }
@@ -265,10 +265,10 @@ func (rg *routeGenerator) getAdvertisedRoutes(key string) []string {
 
 }
 
-// advertiseRoutes associates only the given routes with the given key,
+// setRoutesForKey associates only the given routes with the given key,
 // and advertises the given routes. It also withdraws any routes that are no
 // longer associated with the given key.
-func (rg *routeGenerator) advertiseRoutes(key string, routes []string) {
+func (rg *routeGenerator) setRoutesForKey(key string, routes []string) {
 
 	advertisedRoutes := rg.svcRouteMap[key]
 	if advertisedRoutes == nil {
@@ -387,7 +387,7 @@ func (rg *routeGenerator) unsetRouteForSvc(obj interface{}) {
 	defer rg.Unlock()
 
 	routes := rg.getAdvertisedRoutes(key)
-	rg.withdrawRoutes(key, routes)
+	rg.withdrawRoutesForKey(key, routes)
 
 }
 
@@ -416,9 +416,9 @@ func (rg *routeGenerator) withdrawRoute(key, route string) {
 	}
 }
 
-// withdrawRoutes withdraws the given routes associated with the given key and
-// removes them from the cache.
-func (rg *routeGenerator) withdrawRoutes(key string, routes []string) {
+// withdrawRoutesForKey withdraws the given routes associated with the given key
+// and removes them from the cache.
+func (rg *routeGenerator) withdrawRoutesForKey(key string, routes []string) {
 	for _, route := range routes {
 		rg.withdrawRoute(key, route)
 	}

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -262,7 +262,7 @@ func (rg *routeGenerator) isAllowedExternalRoute(route string) bool {
 		return false
 	}
 
-	for _, allowedNet := range rg.client.externalIPCIDRs {
+	for _, allowedNet := range rg.client.externalIPNets {
 		if allowedNet.Contains(routeIP) {
 			return true
 		}

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -211,7 +211,6 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 func (rg *routeGenerator) onBGPConfigurationUpdate() {
 
 	// Get all the services that we know about
-	svcs := make([]*v1.Service, 0)
 	svcIfaces := rg.svcIndexer.List()
 	for _, svcIface := range svcIfaces {
 		svc, ok := svcIface.(*v1.Service)
@@ -220,11 +219,7 @@ func (rg *routeGenerator) onBGPConfigurationUpdate() {
 			continue
 		}
 
-		svcs = append(svcs, svc)
-	}
-
-	// Update the routes advertised for each service
-	for _, svc := range svcs {
+		// Update the routes advertised for this service
 		rg.setRouteForSvc(svc, nil)
 	}
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -261,7 +261,7 @@ func (rg *routeGenerator) isAllowedExternalRoute(route string) bool {
 
 	routeIP, _, err := net.ParseCIDR(route)
 	if err != nil {
-		log.Errorf("Could not parse service External IP: %s: %v", route, err)
+		log.WithError(err).Errorf("Could not parse service External IP: %s", route)
 		return false
 	}
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -421,7 +421,7 @@ func (rg *routeGenerator) withdrawRoute(key, route string) {
 	}
 }
 
-// withdrawRoutes withdraws all routes associated with the given key and
+// withdrawRoutes withdraws the given routes associated with the given key and
 // removes them from the cache.
 func (rg *routeGenerator) withdrawRoutes(key string, routes []string) {
 	for _, route := range routes {

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -231,6 +231,7 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 
 			// Only advertise whitelisted External IP's
 			if !rg.isAllowedExternalRoute(route) {
+				log.Infof("External IP not advertised as not whitelisted: %s", route)
 				continue
 			}
 
@@ -372,7 +373,7 @@ func (rg *routeGenerator) withdrawClusterRoute(key, route string) {
 // advertiseExternalRoute advertises a route for a service ExternalIP and
 // caches it.
 func (rg *routeGenerator) advertiseExternalRoute(key, route string) {
-	if rg.svcExternalRouteMap[key] == nil {
+	if _, hasKey := rg.svcExternalRouteMap[key]; !hasKey {
 		rg.svcExternalRouteMap[key] = make(map[string]bool)
 	}
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -249,6 +249,8 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 			}
 		}
 
+	} else {
+		rg.unsetExternalRoutesForSvc(key)
 	}
 
 }
@@ -350,12 +352,18 @@ func (rg *routeGenerator) unsetRouteForSvc(obj interface{}) {
 	}
 
 	// Remove all External IP's
+	rg.unsetExternalRoutesForSvc(key)
+
+}
+
+// unsetExternalRoutesForSvc withdraws all routes for the service with
+// the given key.
+func (rg *routeGenerator) unsetExternalRoutesForSvc(key string) {
 	if rg.svcExternalRouteMap[key] != nil {
 		for route := range rg.svcExternalRouteMap[key] {
 			rg.withdrawExternalRoute(key, route)
 		}
 	}
-
 }
 
 // advertiseClusterRoute advertises a route for a service ClusterIP and caches it.

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -361,9 +361,6 @@ func (rg *routeGenerator) unsetExternalRoutesForSvc(key string) {
 		for route := range rg.svcExternalRouteMap[key] {
 			rg.withdrawExternalRoute(key, route)
 		}
-		if len(rg.svcExternalRouteMap[key]) == 0 {
-			delete(rg.svcExternalRouteMap, key)
-		}
 	}
 }
 
@@ -397,6 +394,10 @@ func (rg *routeGenerator) withdrawExternalRoute(key, route string) {
 
 	if rg.svcExternalRouteMap[key] != nil {
 		delete(rg.svcExternalRouteMap[key], route)
+	}
+
+	if len(rg.svcExternalRouteMap[key]) == 0 {
+		delete(rg.svcExternalRouteMap, key)
 	}
 }
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -197,7 +197,8 @@ func (rg *routeGenerator) setRouteForSvc(svc *v1.Service, ep *v1.Endpoints) {
 	rg.Lock()
 	defer rg.Unlock()
 
-	if rg.advertiseThisService(svc, ep) {
+	advertise := rg.advertiseThisService(svc, ep)
+	if advertise {
 		route := svc.Spec.ClusterIP + "/32"
 		if cur, exists := rg.svcClusterRouteMap[key]; !exists {
 			// This is a new route - send it through.

--- a/pkg/backends/calico/routes_test.go
+++ b/pkg/backends/calico/routes_test.go
@@ -41,22 +41,22 @@ func buildSimpleService() (svc *v1.Service, ep *v1.Endpoints) {
 
 var _ = Describe("RouteGenerator", func() {
 	var rg *routeGenerator
-	var expectedExternalRouteMap map[string]bool
+	var expectedSvcRouteMap map[string]bool
 
 	BeforeEach(func() {
 
 		_, ipNet1, _ := net.ParseCIDR("104.244.42.129/32")
 		_, ipNet2, _ := net.ParseCIDR("172.217.3.0/24")
 
-		expectedExternalRouteMap = make(map[string]bool)
-		expectedExternalRouteMap["172.217.3.5/32"] = true
+		expectedSvcRouteMap = make(map[string]bool)
+		expectedSvcRouteMap["127.0.0.1/32"] = true
+		expectedSvcRouteMap["172.217.3.5/32"] = true
 
 		rg = &routeGenerator{
-			nodeName:            "foobar",
-			svcIndexer:          cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
-			epIndexer:           cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
-			svcClusterRouteMap:  make(map[string]string),
-			svcExternalRouteMap: make(map[string]map[string]bool),
+			nodeName:    "foobar",
+			svcIndexer:  cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
+			epIndexer:   cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
+			svcRouteMap: make(map[string]map[string]bool),
 			client: &client{
 				cache:  make(map[string]string),
 				synced: true,
@@ -100,13 +100,10 @@ var _ = Describe("RouteGenerator", func() {
 				err := rg.epIndexer.Add(ep)
 				Expect(err).NotTo(HaveOccurred())
 				rg.setRouteForSvc(svc, nil)
-				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
-				fmt.Fprintln(GinkgoWriter, rg.svcExternalRouteMap)
-				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
-					expectedExternalRouteMap))
+				fmt.Fprintln(GinkgoWriter, rg.svcRouteMap)
+				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				rg.unsetRouteForSvc(ep)
-				Expect(rg.svcClusterRouteMap["foo/bar"]).To(BeEmpty())
-				Expect(rg.svcExternalRouteMap["foo/bar"]).To(BeEmpty())
+				Expect(rg.svcRouteMap["foo/bar"]).To(BeEmpty())
 			})
 		})
 		Context("svc = nil, ep = ep", func() {
@@ -117,11 +114,9 @@ var _ = Describe("RouteGenerator", func() {
 				err := rg.svcIndexer.Add(svc)
 				Expect(err).NotTo(HaveOccurred())
 				rg.setRouteForSvc(nil, ep)
-				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
-					expectedExternalRouteMap))
+				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				rg.unsetRouteForSvc(ep)
-				Expect(rg.svcClusterRouteMap["foo/bar"]).To(BeEmpty())
+				Expect(rg.svcRouteMap["foo/bar"]).To(BeEmpty())
 			})
 		})
 	})
@@ -147,9 +142,7 @@ var _ = Describe("RouteGenerator", func() {
 			initRevision := rg.client.cacheRevision
 			rg.onSvcAdd(svc)
 			Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-			Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
-			Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
-				expectedExternalRouteMap))
+			Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
@@ -159,149 +152,85 @@ var _ = Describe("RouteGenerator", func() {
 			Expect(err).NotTo(HaveOccurred())
 			rg.onEPAdd(ep)
 			Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-			Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal(""))
-			Expect(rg.svcExternalRouteMap["foo/bar"]).To(BeEmpty())
+			Expect(rg.svcRouteMap["foo/bar"]).To(BeEmpty())
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal(""))
 			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal(""))
 			Expect(rg.client.cache).To(Equal(map[string]string{}))
 		})
 
 		Context("onSvc[Add|Delete]", func() {
-			It("should add the service's clusterIP into the svcClusterRouteMap", func() {
+			It("should add the service's cluster IP and whitelisted external IPs into the svcRouteMap", func() {
 				// add
 				initRevision := rg.client.cacheRevision
 				rg.onSvcAdd(svc)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
-
-				// delete
-				rg.onSvcDelete(svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-				Expect(rg.svcClusterRouteMap).ToNot(HaveKey("foo/bar"))
-				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
-			})
-		})
-
-		Context("onSvc[Add|Delete]", func() {
-			It("should add the service's whitelisted externalIPs into the svcExternalRouteMap", func() {
-				// add
-				initRevision := rg.client.cacheRevision
-				rg.onSvcAdd(svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
-					expectedExternalRouteMap))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
 				// delete
 				rg.onSvcDelete(svc)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1/32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
 		})
 
 		Context("onSvcUpdate", func() {
-			It("should add the service's whitelisted externalIPs into the svcExternalRouteMap and then remove them for unsupported service type", func() {
+			It("should add the service's cluster IP and whitelisted external IPs into the svcRouteMap and then remove them for unsupported service type", func() {
 				initRevision := rg.client.cacheRevision
 				rg.onSvcUpdate(nil, svc)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
-					expectedExternalRouteMap))
+				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
+				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
 				// set to unsupport service type
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				rg.onSvcUpdate(nil, svc)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
-			})
-		})
-
-		Context("onSvcUpdate", func() {
-			It("should add the service's clusterIP into the svcClusterRouteMap and then remove it for unsupported service type", func() {
-				initRevision := rg.client.cacheRevision
-				rg.onSvcUpdate(nil, svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
-				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
-
-				// set to unsupport service type
-				svc.Spec.Type = v1.ServiceTypeExternalName
-				rg.onSvcUpdate(nil, svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-				Expect(rg.svcClusterRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
 		})
 
 		Context("onEp[Add|Delete]", func() {
-			It("should add the service's clusterIP into the svcClusterRouteMap", func() {
+			It("should add the service's cluster IP and whitelisted external IPs into the svcRouteMap", func() {
 				// add
 				initRevision := rg.client.cacheRevision
 				rg.onEPAdd(ep)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
 				// delete
 				rg.onEPDelete(ep)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-				Expect(rg.svcClusterRouteMap).ToNot(HaveKey("foo/bar"))
+				Expect(rg.svcRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
-			})
-		})
-
-		Context("onEp[Add|Delete]", func() {
-			It("should add the service's whitelisted externalIPs into the svcExternalRouteMap", func() {
-				// add
-				initRevision := rg.client.cacheRevision
-				rg.onEPAdd(ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
-					expectedExternalRouteMap))
-				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
-
-				// delete
-				rg.onEPDelete(ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 			})
 		})
 
 		Context("onEpDelete", func() {
-			It("should add the service's whitelisted externalIPs into the svcExternalRouteMap and then remove it for unsupported service type", func() {
+			It("should add the service's cluster IP and whitelisted external IPs into the svcRouteMap and then remove it for unsupported service type", func() {
 				initRevision := rg.client.cacheRevision
 				rg.onEPUpdate(nil, ep)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
-					expectedExternalRouteMap))
+				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
 				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
-
-				// set to unsupport service type
-				svc.Spec.Type = v1.ServiceTypeExternalName
-				rg.onEPUpdate(nil, ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-				Expect(rg.svcExternalRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
-				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
-			})
-		})
-
-		Context("onEpDelete", func() {
-			It("should add the service's clusterIP into the svcClusterRouteMap and then remove it for unsupported service type", func() {
-				initRevision := rg.client.cacheRevision
-				rg.onEPUpdate(nil, ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
-				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// set to unsupport service type
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				rg.onEPUpdate(nil, ep)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
-				Expect(rg.svcClusterRouteMap).ToNot(HaveKey("foo/bar"))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
 		})

--- a/pkg/backends/calico/routes_test.go
+++ b/pkg/backends/calico/routes_test.go
@@ -58,13 +58,13 @@ var _ = Describe("RouteGenerator", func() {
 			epIndexer:               cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
 			svcRouteMap:             make(map[string]map[string]bool),
 			routeAdvertisementCount: make(map[string]int),
+			externalIPNets: []*net.IPNet{
+				ipNet1,
+				ipNet2,
+			},
 			client: &client{
 				cache:  make(map[string]string),
 				synced: true,
-				externalIPNets: []*net.IPNet{
-					ipNet1,
-					ipNet2,
-				},
 			},
 		}
 		rg.client.watcherCond = sync.NewCond(&rg.client.cacheLock)

--- a/pkg/backends/calico/routes_test.go
+++ b/pkg/backends/calico/routes_test.go
@@ -1,6 +1,8 @@
 package calico
 
 import (
+	"fmt"
+	"net"
 	"sync"
 
 	. "github.com/onsi/ginkgo"
@@ -26,6 +28,10 @@ func buildSimpleService() (svc *v1.Service, ep *v1.Endpoints) {
 			Type:                  v1.ServiceTypeClusterIP,
 			ClusterIP:             "127.0.0.1",
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			ExternalIPs: []string{
+				"45.12.70.5",
+				"172.217.3.5",
+			},
 		}}
 	ep = &v1.Endpoints{
 		ObjectMeta: meta,
@@ -35,15 +41,29 @@ func buildSimpleService() (svc *v1.Service, ep *v1.Endpoints) {
 
 var _ = Describe("RouteGenerator", func() {
 	var rg *routeGenerator
+	var expectedExternalRouteMap map[string]bool
+
 	BeforeEach(func() {
+
+		_, ipNet1, _ := net.ParseCIDR("104.244.42.129/32")
+		_, ipNet2, _ := net.ParseCIDR("172.217.3.0/24")
+
+		expectedExternalRouteMap = make(map[string]bool)
+		expectedExternalRouteMap["172.217.3.5/32"] = true
+
 		rg = &routeGenerator{
-			nodeName:           "foobar",
-			svcIndexer:         cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
-			epIndexer:          cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
-			svcClusterRouteMap: make(map[string]string),
+			nodeName:            "foobar",
+			svcIndexer:          cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
+			epIndexer:           cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
+			svcClusterRouteMap:  make(map[string]string),
+			svcExternalRouteMap: make(map[string]map[string]bool),
 			client: &client{
 				cache:  make(map[string]string),
 				synced: true,
+				externalIPNets: []*net.IPNet{
+					ipNet1,
+					ipNet2,
+				},
 			},
 		}
 		rg.client.watcherCond = sync.NewCond(&rg.client.cacheLock)
@@ -73,7 +93,7 @@ var _ = Describe("RouteGenerator", func() {
 
 	Describe("(un)setRouteForSvc", func() {
 		Context("svc = svc, ep = nil", func() {
-			It("should set an unset routes for a service", func() {
+			It("should set and unset routes for a service", func() {
 				svc, ep := buildSimpleService()
 				addEndpointSubset(ep, rg.nodeName)
 
@@ -81,8 +101,12 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(err).NotTo(HaveOccurred())
 				rg.setRouteForSvc(svc, nil)
 				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
+				fmt.Fprintln(GinkgoWriter, rg.svcExternalRouteMap)
+				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
+					expectedExternalRouteMap))
 				rg.unsetRouteForSvc(ep)
 				Expect(rg.svcClusterRouteMap["foo/bar"]).To(BeEmpty())
+				Expect(rg.svcExternalRouteMap["foo/bar"]).To(BeEmpty())
 			})
 		})
 		Context("svc = nil, ep = ep", func() {
@@ -94,6 +118,8 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(err).NotTo(HaveOccurred())
 				rg.setRouteForSvc(nil, ep)
 				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
+					expectedExternalRouteMap))
 				rg.unsetRouteForSvc(ep)
 				Expect(rg.svcClusterRouteMap["foo/bar"]).To(BeEmpty())
 			})
@@ -116,22 +142,27 @@ var _ = Describe("RouteGenerator", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should remove clusterIPs when endpoints are deleted", func() {
+		It("should remove advertised IPs when endpoints are deleted", func() {
 			// Trigger a service add - it should update the cache with its route.
 			initRevision := rg.client.cacheRevision
 			rg.onSvcAdd(svc)
-			Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
+			Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 			Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
+			Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
+				expectedExternalRouteMap))
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
 
-			// Simulate the remove of the local endpoint. It should withdraw the route.
+			// Simulate the remove of the local endpoint. It should withdraw the routes.
 			ep.Subsets = []v1.EndpointSubset{}
 			err := rg.epIndexer.Add(ep)
 			Expect(err).NotTo(HaveOccurred())
 			rg.onEPAdd(ep)
-			Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+			Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 			Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal(""))
+			Expect(rg.svcExternalRouteMap["foo/bar"]).To(BeEmpty())
 			Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal(""))
+			Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal(""))
 			Expect(rg.client.cache).To(Equal(map[string]string{}))
 		})
 
@@ -140,15 +171,51 @@ var _ = Describe("RouteGenerator", func() {
 				// add
 				initRevision := rg.client.cacheRevision
 				rg.onSvcAdd(svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// delete
 				rg.onSvcDelete(svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 				Expect(rg.svcClusterRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+			})
+		})
+
+		Context("onSvc[Add|Delete]", func() {
+			It("should add the service's whitelisted externalIPs into the svcExternalRouteMap", func() {
+				// add
+				initRevision := rg.client.cacheRevision
+				rg.onSvcAdd(svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
+					expectedExternalRouteMap))
+				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
+
+				// delete
+				rg.onSvcDelete(svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
+			})
+		})
+
+		Context("onSvcUpdate", func() {
+			It("should add the service's whitelisted externalIPs into the svcExternalRouteMap and then remove them for unsupported service type", func() {
+				initRevision := rg.client.cacheRevision
+				rg.onSvcUpdate(nil, svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
+					expectedExternalRouteMap))
+				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
+
+				// set to unsupport service type
+				svc.Spec.Type = v1.ServiceTypeExternalName
+				rg.onSvcUpdate(nil, svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 			})
 		})
 
@@ -156,14 +223,14 @@ var _ = Describe("RouteGenerator", func() {
 			It("should add the service's clusterIP into the svcClusterRouteMap and then remove it for unsupported service type", func() {
 				initRevision := rg.client.cacheRevision
 				rg.onSvcUpdate(nil, svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// set to unsupport service type
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				rg.onSvcUpdate(nil, svc)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 				Expect(rg.svcClusterRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})
@@ -174,15 +241,51 @@ var _ = Describe("RouteGenerator", func() {
 				// add
 				initRevision := rg.client.cacheRevision
 				rg.onEPAdd(ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// delete
 				rg.onEPDelete(ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 				Expect(rg.svcClusterRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+			})
+		})
+
+		Context("onEp[Add|Delete]", func() {
+			It("should add the service's whitelisted externalIPs into the svcExternalRouteMap", func() {
+				// add
+				initRevision := rg.client.cacheRevision
+				rg.onEPAdd(ep)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
+					expectedExternalRouteMap))
+				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
+
+				// delete
+				rg.onEPDelete(ep)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
+			})
+		})
+
+		Context("onEpDelete", func() {
+			It("should add the service's whitelisted externalIPs into the svcExternalRouteMap and then remove it for unsupported service type", func() {
+				initRevision := rg.client.cacheRevision
+				rg.onEPUpdate(nil, ep)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).To(Equal(
+					expectedExternalRouteMap))
+				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
+
+				// set to unsupport service type
+				svc.Spec.Type = v1.ServiceTypeExternalName
+				rg.onEPUpdate(nil, ep)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.svcExternalRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
 			})
 		})
 
@@ -190,14 +293,14 @@ var _ = Describe("RouteGenerator", func() {
 			It("should add the service's clusterIP into the svcClusterRouteMap and then remove it for unsupported service type", func() {
 				initRevision := rg.client.cacheRevision
 				rg.onEPUpdate(nil, ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 1))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
 				Expect(rg.svcClusterRouteMap["foo/bar"]).To(Equal("127.0.0.1/32"))
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// set to unsupport service type
 				svc.Spec.Type = v1.ServiceTypeExternalName
 				rg.onEPUpdate(nil, ep)
-				Expect(rg.client.cacheRevision).To(Equal(initRevision + 2))
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
 				Expect(rg.svcClusterRouteMap).ToNot(HaveKey("foo/bar"))
 				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
 			})

--- a/pkg/backends/calico/routes_test.go
+++ b/pkg/backends/calico/routes_test.go
@@ -39,9 +39,29 @@ func buildSimpleService() (svc *v1.Service, ep *v1.Endpoints) {
 	return
 }
 
+func buildSimpleService2() (svc *v1.Service, ep *v1.Endpoints) {
+	meta := metav1.ObjectMeta{Namespace: "foo", Name: "rem"}
+	svc = &v1.Service{
+		ObjectMeta: meta,
+		Spec: v1.ServiceSpec{
+			Type:                  v1.ServiceTypeClusterIP,
+			ClusterIP:             "127.0.0.5",
+			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
+			ExternalIPs: []string{
+				"45.12.70.5",
+				"172.217.3.5",
+			},
+		}}
+	ep = &v1.Endpoints{
+		ObjectMeta: meta,
+	}
+	return
+}
+
 var _ = Describe("RouteGenerator", func() {
 	var rg *routeGenerator
 	var expectedSvcRouteMap map[string]bool
+	var expectedSvc2RouteMap map[string]bool
 
 	BeforeEach(func() {
 
@@ -51,6 +71,10 @@ var _ = Describe("RouteGenerator", func() {
 		expectedSvcRouteMap = make(map[string]bool)
 		expectedSvcRouteMap["127.0.0.1/32"] = true
 		expectedSvcRouteMap["172.217.3.5/32"] = true
+
+		expectedSvc2RouteMap = make(map[string]bool)
+		expectedSvc2RouteMap["127.0.0.5/32"] = true
+		expectedSvc2RouteMap["172.217.3.5/32"] = true
 
 		rg = &routeGenerator{
 			nodeName:                "foobar",
@@ -124,17 +148,23 @@ var _ = Describe("RouteGenerator", func() {
 
 	Describe("resourceInformerHandlers", func() {
 		var (
-			svc *v1.Service
-			ep  *v1.Endpoints
+			svc, svc2 *v1.Service
+			ep, ep2   *v1.Endpoints
 		)
 
 		BeforeEach(func() {
 			svc, ep = buildSimpleService()
+			svc2, ep2 = buildSimpleService2()
 
 			addEndpointSubset(ep, rg.nodeName)
+			addEndpointSubset(ep2, rg.nodeName)
 			err := rg.epIndexer.Add(ep)
 			Expect(err).NotTo(HaveOccurred())
+			err = rg.epIndexer.Add(ep2)
+			Expect(err).NotTo(HaveOccurred())
 			err = rg.svcIndexer.Add(svc)
+			Expect(err).NotTo(HaveOccurred())
+			err = rg.svcIndexer.Add(svc2)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -178,6 +208,46 @@ var _ = Describe("RouteGenerator", func() {
 				// delete
 				rg.onSvcDelete(svc)
 				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1/32"))
+				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(0))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/172.217.3.5-32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.1-32"))
+			})
+
+			It("should handle two services advertising the same route correctly, only advertising the route once and only withdrawing the route when both services are removed.", func() {
+				// add both services and make sure the duplicate route is counted twice
+				initRevision := rg.client.cacheRevision
+				rg.onSvcAdd(svc)
+				rg.onSvcAdd(svc2)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 4))
+				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
+				Expect(rg.svcRouteMap["foo/rem"]).To(Equal(expectedSvc2RouteMap))
+				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementCount["127.0.0.5/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(2))
+				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutes/127.0.0.5-32"]).To(Equal("127.0.0.5/32"))
+				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
+
+				// delete one of the services, and make sure the duplicate route is still advertised
+				// and we handle the counting logic correctly
+				rg.onSvcDelete(svc2)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 5))
+				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(1))
+				Expect(rg.routeAdvertisementCount["127.0.0.5/32"]).To(Equal(0))
+				Expect(rg.routeAdvertisementCount["172.217.3.5/32"]).To(Equal(1))
+				Expect(rg.svcRouteMap["foo/bar"]).To(Equal(expectedSvcRouteMap))
+				Expect(rg.svcRouteMap["foo/rem"]).ToNot(HaveKey("127.0.0.5/32"))
+				Expect(rg.svcRouteMap["foo/rem"]).ToNot(HaveKey("172.217.3.5/32"))
+				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
+				Expect(rg.client.cache["/calico/staticroutes/172.217.3.5-32"]).To(Equal("172.217.3.5/32"))
+				Expect(rg.client.cache).ToNot(HaveKey("/calico/staticroutes/127.0.0.5-32"))
+
+				// delete the other service and check that both routes are withdrawn and their counts are 0
+				rg.onSvcDelete(svc)
+				Expect(rg.client.cacheRevision).To(Equal(initRevision + 7))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("172.217.3.5/32"))
 				Expect(rg.svcRouteMap["foo/bar"]).ToNot(HaveKey("127.0.0.1/32"))
 				Expect(rg.routeAdvertisementCount["127.0.0.1/32"]).To(Equal(0))


### PR DESCRIPTION
This PR adds support for sending BGP advertisements for service External IP routes (https://github.com/projectcalico/calico/issues/2770). In order to prevent users from advertising arbitrary IP's, we restrict the advertisements to the whitelist defined in the new `ServiceExternalIPs` field (https://github.com/projectcalico/libcalico-go/pull/1123). 

The v1 syncer is used to pass the whitelist from `libcalico-go` through to `confd`.