### PR TITLE
More Service advertisement tests and cleanup

### DIFF
--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -198,10 +198,11 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 		// We only turn it on if configured to do so, to avoid needing to watch services / endpoints.
 		if c.rg, err = NewRouteGenerator(c); err != nil {
 			log.WithError(err).Error("Failed to start route generator, routes will not be advertised")
+		} else {
+			c.rg.onClusterIPsUpdate(clusterCIDRs)
+			c.rg.onExternalIPsUpdate(externalCIDRs)
+			c.rg.Start()
 		}
-		c.rg.onClusterIPsUpdate(clusterCIDRs)
-		c.rg.onExternalIPsUpdate(externalCIDRs)
-		c.rg.Start()
 	} else {
 		c.OnInSync(SourceRouteGenerator)
 	}
@@ -659,6 +660,9 @@ func (c *client) OnUpdates(updates []api.Update) {
 	// Track whether these updates require BGP peerings to be recomputed.
 	needUpdatePeersV1 := false
 
+	// Track whether these updates require service advertisement to be recomputed.
+	needsServiceAdvertismentUpdates := false
+
 	for _, u := range updates {
 		log.Debugf("Update: %#v", u)
 
@@ -678,69 +682,24 @@ func (c *client) OnUpdates(updates []api.Update) {
 			// Not a v3 resource. We care about when the BGP configuration changes - recalculate
 			// peers when we receive AS number updates.
 			if cfgKey, ok := u.Key.(model.GlobalBGPConfigKey); ok {
-				var err error
-
 				if cfgKey.Name == "as_num" {
 					log.Debugf("Global AS number update, recalculate peers")
 					needUpdatePeersV1 = true
 				}
 
 				if cfgKey.Name == "svc_external_ips" {
-					// We may need to start the route generator if this is the first time we've
-					// needed to advertise any services.
-					if c.rg == nil {
-						if c.rg, err = NewRouteGenerator(c); err != nil {
-							log.WithError(err).Error("Failed to start route generator")
-							continue
-						}
-						c.rg.Start()
-					}
-
-					log.Debugf("Global serviceExternalIPs update.")
-					if u.UpdateType == api.UpdateTypeKVDeleted {
-						// Run as a go routine so we don't block. We're already holding the cache lock,
-						// and the route generator will also try to grab it when it learns that
-						// cluster IPs have been updated.
-						go c.rg.onExternalIPsUpdate(nil)
-					} else {
-						// Run as a go routine so we don't block. We're already holding the cache lock,
-						// and the route generator will also try to grab it when it learns that
-						// cluster IPs have been updated.
-						cidrs := strings.Split(u.Value.(string), ",")
-						go c.rg.onExternalIPsUpdate(cidrs)
-					}
+					log.Debugf("Global service external IP ranges  update.")
+					needsServiceAdvertismentUpdates = true
 				}
 
 				if cfgKey.Name == "svc_cluster_ips" {
-					// We may need to start the route generator if this is the first time we've
-					// needed to advertise any services.
-					if c.rg == nil {
-						if c.rg, err = NewRouteGenerator(c); err != nil {
-							log.WithError(err).Error("Failed to start route generator")
-							continue
-						}
-						c.rg.Start()
-					}
-
-					// ClusterIPs are configurable through an environment variable. If specified,
-					// that variable takes precedence over datastore config.
+					log.Debugf("Global service cluster IP ranges update.")
 					if len(os.Getenv(envAdvertiseClusterIPs)) != 0 {
+						// ClusterIPs are configurable through an environment variable. If specified,
+						// that variable takes precedence over datastore config, so we should ignore the update.
 						log.Debugf("Ignoring serviceClusterIPs update due to environment variable %s", envAdvertiseClusterIPs)
-						continue
-					}
-
-					log.Debugf("Global serviceClusterIPs update.")
-					if u.UpdateType == api.UpdateTypeKVDeleted {
-						// Run as a go routine so we don't block. We're already holding the cache lock,
-						// and the route generator will also try to grab it when it learns that
-						// cluster IPs have been updated.
-						go c.rg.onClusterIPsUpdate([]string{})
 					} else {
-						// Run as a go routine so we don't block. We're already holding the cache lock,
-						// and the route generator will also try to grab it when it learns that
-						// cluster IPs have been updated.
-						cidrs := strings.Split(u.Value.(string), ",")
-						go c.rg.onClusterIPsUpdate(cidrs)
+						needsServiceAdvertismentUpdates = true
 					}
 				}
 			}
@@ -830,8 +789,37 @@ func (c *client) OnUpdates(updates []api.Update) {
 		c.updatePeersV1()
 	}
 
+	// If we need to update Service advertisement based on the updates, then do so.
+	if needsServiceAdvertismentUpdates {
+		log.Debug("Recompute service advertisement")
+		if c.rg == nil {
+			// If this is the first time we've needed to start the route generator, then do so here.
+			var err error
+			if c.rg, err = NewRouteGenerator(c); err != nil {
+				log.WithError(err).Error("Failed to start route generator")
+			} else {
+				c.updateRouteAdvertisements()
+				c.rg.Start()
+			}
+		} else {
+			// If the RG is already started, simply update advertisements.
+			c.updateRouteAdvertisements()
+		}
+	}
+
 	// Notify watcher thread that we've received new updates.
 	c.onNewUpdates()
+}
+
+// updateRouteAdvertisements sends updated state to the route generator based on contents of the cache.
+func (c *client) updateRouteAdvertisements() {
+	// Update CIDRs. In v1 format, they are a single comma-separate string. Split on the comma
+	// and pass a list of strings to the route generator.
+	externalIPs := strings.Split(c.cache["/calico/bgp/v1/global/svc_external_ips"], ",")
+	c.rg.onExternalIPsUpdate(externalIPs)
+
+	clusterCIDRs := strings.Split(c.cache["/calico/bgp/v1/global/svc_cluster_ips"], ",")
+	c.rg.onClusterIPsUpdate(clusterCIDRs)
 }
 
 func (c *client) incrementCacheRevision() {

--- a/tests/mock_data/calicoctl/mesh/static-routes/input.yaml
+++ b/tests/mock_data/calicoctl/mesh/static-routes/input.yaml
@@ -3,6 +3,8 @@ apiVersion: projectcalico.org/v3
 metadata:
   name: default
 spec:
+  serviceClusterIPs:
+  - cidr: 10.101.0.0/16
 
 ---
 

--- a/tests/test_suite_common.sh
+++ b/tests/test_suite_common.sh
@@ -24,7 +24,6 @@ execute_test_suite() {
     if [ "$DATASTORE_TYPE" = etcdv3 ]; then
 	run_extra_test test_node_deletion
 	run_extra_test test_idle_peers
-	run_extra_test test_static_routes
 	run_extra_test test_router_id_hash
 	echo "Extra etcdv3 tests passed"
     fi
@@ -53,13 +52,6 @@ run_extra_test() {
     echo "==============================="
     eval $1
     echo "==============================="
-}
-
-test_static_routes() {
-    export CALICO_ADVERTISE_CLUSTER_IPS=10.101.0.0/16
-    run_individual_test_oneshot 'mesh/static-routes'
-    export -n CALICO_ADVERTISE_CLUSTER_IPS
-    unset CALICO_ADVERTISE_CLUSTER_IPS
 }
 
 test_node_deletion() {
@@ -305,6 +297,7 @@ execute_tests_oneshot() {
         run_individual_test_oneshot 'explicit_peering/specific_node'
         run_individual_test_oneshot 'explicit_peering/selectors'
         run_individual_test_oneshot 'explicit_peering/route_reflector'
+        run_individual_test_oneshot 'mesh/static-routes'
     done
 }
 


### PR DESCRIPTION
- Switches from using the env var to the new datastore configuration for cluster IP advertisement tests.
- Adds a few new UTs
- Commonizes the RG logic in OnUpdates 