### PR TITLE
Handle empty service IPs in BGP config update

### DIFF
--- a/pkg/backends/calico/routes_test.go
+++ b/pkg/backends/calico/routes_test.go
@@ -132,8 +132,8 @@ var _ = Describe("RouteGenerator", func() {
 		verifyInitialState()
 
 		invalidNets := [][]string{
-			{""},
-			{"10.10.1.0/24", ""},
+			{"invalid"},
+			{"10.10.1.0/24", "invalid"},
 			{"10.10.1.0/24", "x.y.z.z/12"},
 		}
 		for _, n := range invalidNets {


### PR DESCRIPTION
The values of `/calico/bgp/v1/global/svc_external_ips` or `/calico/bgp/v1/global/svc_cluster_ips` turn out to be empty strings when a BGP config update is processed where the BGP config has no external IPs or cluster IPs. So when an existing BGP config containing service IPs is replaced with one with no service IPs, the result is that previously advertised routes are not withdrawn.