### PR TITLE
Don't prevent mesh peerings when routeReflectorClusterID is defined

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -85,10 +85,6 @@ template bgp bgp_template {
 # ------------- Node-to-node mesh -------------
 {{- $node_cid_key := printf "/host/%s/rr_cluster_id" (getenv "NODENAME")}}
 {{- $node_cluster_id := getv $node_cid_key}}
-{{- if ne "" ($node_cluster_id)}}
-# This node is configured as a route reflector with cluster ID {{$node_cluster_id}};
-# ignore node-to-node mesh setting.
-{{- else}}
 {{if (json (getv "/global/node_mesh")).enabled}}
 {{range $host := lsdir "/host"}}
 {{$onode_as_key := printf "/host/%s/as_num" .}}
@@ -111,7 +107,6 @@ template bgp bgp_template {
 {{else}}
 # Node-to-node mesh disabled
 {{end}}
-{{- end}}
 
 
 # ------------- Global peers -------------

--- a/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
@@ -50,8 +50,8 @@ template bgp bgp_template {
 }
 
 # ------------- Node-to-node mesh -------------
-# This node is configured as a route reflector with cluster ID 10.0.0.1;
-# ignore node-to-node mesh setting.
+
+# Node-to-node mesh disabled
 
 
 # ------------- Global peers -------------


### PR DESCRIPTION
This isn't necessary and in some cases can prevent a node from switching
from route-reflector back to full-mesh mode.

```release-note
Don't prevent mesh peerings when routeReflectorClusterID is defined since this may be an issue if a node is switching back from route-reflector to mesh mode
```