### PR TITLE
Exclude kube-ipvs0 from bird routing

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -57,7 +57,15 @@ protocol device {
 
 protocol direct {
 {{- template "LOGGING"}}
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 {{if eq "" ($node_ip)}}# IPv4 disabled on this node.

--- a/etc/calico/confd/templates/bird6.cfg.template
+++ b/etc/calico/confd/templates/bird6.cfg.template
@@ -57,7 +57,15 @@ protocol device {
 
 protocol direct {
 {{- template "LOGGING"}}
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 {{if eq "" ($node_ip6)}}# IPv6 disabled on this node.

--- a/tests/compiled_templates/explicit_peering/global/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/global/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug all;
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/explicit_peering/global/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/global/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug all;
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/explicit_peering/route_reflector/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/route_reflector/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/explicit_peering/selectors/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/explicit_peering/selectors/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/explicit_peering/specific_node/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/specific_node/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/explicit_peering/specific_node/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/specific_node/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/hash/bird.cfg
+++ b/tests/compiled_templates/mesh/hash/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/mesh/hash/bird6.cfg
+++ b/tests/compiled_templates/mesh/hash/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/ipip-always/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-always/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/mesh/ipip-always/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-always/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/ipip-cross-subnet/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-cross-subnet/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/mesh/ipip-cross-subnet/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-cross-subnet/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/ipip-off/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-off/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/mesh/ipip-off/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-off/bird6.cfg
@@ -26,7 +26,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 # IPv4 disabled on this node.

--- a/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/static-routes/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/mesh/vxlan-always/bird.cfg
+++ b/tests/compiled_templates/mesh/vxlan-always/bird.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 

--- a/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
+++ b/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
@@ -27,7 +27,15 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", "*"; # Exclude cali* but include everything else.
+  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
+                                          # include everything else.  In
+                                          # IPVS-mode, kube-proxy creates a
+                                          # kube-ipvs0 interface. We exclude
+                                          # kube-ipvs0 because this interface
+                                          # gets an address for every in use
+                                          # cluster IP. We use static routes
+                                          # for when we legitimately want to
+                                          # export cluster IPs.
 }
 
 # IPv6 disabled on this node.


### PR DESCRIPTION
Fixes https://github.com/projectcalico/calico/issues/2967

