### PR TITLE
Program blackhole routes for full rejectcidrs to avoid route loops

### DIFF
--- a/etc/calico/confd/templates/bird6_ipam.cfg.template
+++ b/etc/calico/confd/templates/bird6_ipam.cfg.template
@@ -23,11 +23,12 @@ filter calico_kernel_programming {
 {{- $reject_key := "/rejectcidrsv6"}}
 {{- if ls $reject_key}}
 
-  # Don't program static routes into kernel.
+  # Don't program static routes into kernel, except for the full reject CIDRs.
+  # This prevents route loops with the ToR for non-existent service IPs.
   {{- range ls $reject_key}}
     {{- $parts := split . "-"}}
     {{- $cidr := join $parts "/"}}
-  if ( net ~ {{$cidr}} ) then { reject; }
+  if ( net ~ {{$cidr}} ) && ( net != {{$cidr}} ) then { reject; }
   {{- end}}
 
 {{- end}}

--- a/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -24,11 +24,12 @@ filter calico_kernel_programming {
 {{- $reject_key := "/rejectcidrs"}}
 {{- if ls $reject_key}}
 
-  # Don't program static routes into kernel.
+  # Don't program static routes into kernel, except for the full reject CIDRs.
+  # This prevents route loops with the ToR for non-existent service IPs.
   {{- range ls $reject_key}}
     {{- $parts := split . "-"}}
     {{- $cidr := join $parts "/"}}
-  if ( net ~ {{$cidr}} ) then { reject; }
+  if ( net ~ {{$cidr}} ) && ( net != {{$cidr}} ) then { reject; }
   {{- end}}
 
 {{- end}}

--- a/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird_ipam.cfg
+++ b/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird_ipam.cfg
@@ -16,7 +16,8 @@ filter calico_export_to_bgp_peers {
 
 filter calico_kernel_programming {
 
-  # Don't program static routes into kernel.
-  if ( net ~ 10.101.0.0/16 ) then { reject; }
+  # Don't program static routes into kernel, except for the full reject CIDRs.
+  # This prevents route loops with the ToR for non-existent service IPs.
+  if ( net ~ 10.101.0.0/16 ) && ( net != 10.101.0.0/16 ) then { reject; }
   accept;
 }

--- a/tests/compiled_templates/mesh/static-routes/bird6_ipam.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird6_ipam.cfg
@@ -11,7 +11,8 @@ filter calico_export_to_bgp_peers {
 
 filter calico_kernel_programming {
 
-  # Don't program static routes into kernel.
-  if ( net ~ fd00:96::/112 ) then { reject; }
+  # Don't program static routes into kernel, except for the full reject CIDRs.
+  # This prevents route loops with the ToR for non-existent service IPs.
+  if ( net ~ fd00:96::/112 ) && ( net != fd00:96::/112 ) then { reject; }
   accept;
 }

--- a/tests/compiled_templates/mesh/static-routes/bird_ipam.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird_ipam.cfg
@@ -16,8 +16,9 @@ filter calico_export_to_bgp_peers {
 
 filter calico_kernel_programming {
 
-  # Don't program static routes into kernel.
-  if ( net ~ 10.101.0.0/16 ) then { reject; }
+  # Don't program static routes into kernel, except for the full reject CIDRs.
+  # This prevents route loops with the ToR for non-existent service IPs.
+  if ( net ~ 10.101.0.0/16 ) && ( net != 10.101.0.0/16 ) then { reject; }
 
   if ( net ~ 192.168.0.0/16 ) then {
 


### PR DESCRIPTION
If nodes have a default route to a Tor which has been advertised a service IP range,
any packets to an IP:port in the service range that doesn't correspond to a service
will route loop to the ToR until hitting the TTL.  This is bad.  Prevent this by
programming a blackhole route for the service ClusterIPs and ExternalIPs.