### PR TITLE
Rework to remove race handling service advertisement config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ test-etcd: bin/confd bin/etcdctl bin/bird bin/bird6 bin/calico-node bin/kubectl 
 
 .PHONY: ut
 ## Run the fast set of unit tests in a container.
-ut: $(LOCAL_BUILD_DEP) test-kdd test-etcd
+ut: $(LOCAL_BUILD_DEP)
 	$(DOCKER_RUN) --privileged $(CALICO_BUILD) sh -c 'cd /go/src/$(PACKAGE_NAME) && ginkgo -r .'
 
 ## Etcd is used by the kubernetes

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -126,8 +126,7 @@ func NewCalicoClient(confdConfig *config.Config) (*client, error) {
 	c.watcherCond = sync.NewCond(&c.cacheLock)
 
 	// Increment the waitForSync wait group.  This blocks the GetValues call until the
-	// syncer has completed its initial snapshot and is in sync.  The syncer is started
-	// from the SetPrefixes() call from confd.
+	// syncer has completed its initial snapshot and is in sync.
 	c.waitForSync.Add(1)
 
 	// Get cluster CIDRs. Prefer the env var, if specified.
@@ -325,6 +324,8 @@ type client struct {
 // This client uses this information to initialize the revision map used to keep track of the
 // revision number of each prefix that the template is monitoring.
 func (c *client) SetPrefixes(keys []string) error {
+	c.cacheLock.Lock()
+	defer c.cacheLock.Unlock()
 	log.Debugf("Set prefixes called with: %v", keys)
 	for _, k := range keys {
 		// Initialise the revision that we are watching for this prefix.  This will be updated

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -844,12 +844,7 @@ func (c *client) OnUpdates(updates []api.Update) {
 		if c.rg != nil {
 			// Trigger the route generator to recheck and advertise or withdraw
 			// node-specific routes.
-			select {
-			case c.rg.resyncKnownRoutesTrigger <- struct{}{}:
-				log.Debug("Triggered route generator to resync known routes")
-			default:
-				log.Debug("Route generator already has pending resync trigger")
-			}
+			c.rg.TriggerResync()
 		}
 	}
 

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -836,9 +836,14 @@ func (c *client) OnUpdates(updates []api.Update) {
 		}
 
 		if c.rg != nil {
-			// Ask the route generator to recheck and advertise or withdraw
+			// Trigger the route generator to recheck and advertise or withdraw
 			// node-specific routes.
-			go c.rg.resyncKnownRoutes()
+			select {
+			case c.rg.resyncKnownRoutesTrigger <- struct{}{}:
+				log.Debug("Triggered route generator to resync known routes")
+			default:
+				log.Debug("Route generator already has pending resync trigger")
+			}
 		}
 	}
 

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Tigera, Inc. All rights reserved.
+// Copyright (c) 2017-2018,2020 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/backends/calico/client.go
+++ b/pkg/backends/calico/client.go
@@ -809,7 +809,7 @@ func (c *client) OnUpdates(updates []api.Update) {
 			log.Info("Starting route generator due to service advertisement update")
 			var err error
 			if c.rg, err = NewRouteGenerator(c); err != nil {
-				log.WithError(err).Error("Failed to start route generator, unable to advertise services")
+				log.WithError(err).Error("Failed to start route generator, unable to advertise node-specific service routes")
 				c.rg = nil
 			} else {
 				c.rg.Start()
@@ -817,7 +817,7 @@ func (c *client) OnUpdates(updates []api.Update) {
 		}
 
 		if c.rg != nil {
-			// Update CIDRs. In v1 format, they are a single comma-separate string. If the string isn't empty,
+			// Update CIDRs. In v1 format, they are a single comma-separated string. If the string isn't empty,
 			// split on the comma and pass a list of strings to the route generator.
 			// An empty string indicates a withdrawal of that set of service IPs.
 			var externalIPs []string

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -372,7 +372,7 @@ func (rg *routeGenerator) setRoutesForKey(key string, routes []string) {
 }
 
 // isAllowedExternalIP determines if the given IP is in the list of
-// whitelisted External IP CIDR's given in the default bgpconfiguration.
+// whitelisted External IP CIDRs given in the default bgpconfiguration.
 func (rg *routeGenerator) isAllowedExternalIP(externalIP string) bool {
 
 	ip := net.ParseIP(externalIP)
@@ -472,7 +472,6 @@ func (rg *routeGenerator) unsetRouteForSvc(obj interface{}) {
 
 	routes := rg.getAdvertisedRoutes(key)
 	rg.withdrawRoutesForKey(key, routes)
-
 }
 
 // advertiseRoute advertises a route associated with the given key and

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -123,6 +123,16 @@ func (rg *routeGenerator) Start() {
 	}()
 }
 
+// Called by the client to trigger us to recheck and advertise or withdraw node-specific routes.
+func (rg *routeGenerator) TriggerResync() {
+	select {
+	case rg.resyncKnownRoutesTrigger <- struct{}{}:
+		log.Debug("Triggered route generator to resync known routes")
+	default:
+		log.Debug("Route generator already has pending resync trigger")
+	}
+}
+
 // getServiceForEndpoints retrieves the corresponding svc for the given ep
 func (rg *routeGenerator) getServiceForEndpoints(ep *v1.Endpoints) (*v1.Service, string) {
 	// get key

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -117,11 +117,8 @@ func (rg *routeGenerator) Start() {
 		log.Info("RouteGenerator in sync")
 
 		// Loop waiting for trigger to recheck node-specific routes.
-		for {
-			select {
-			case <-rg.resyncKnownRoutesTrigger:
-				rg.resyncKnownRoutes()
-			}
+		for range rg.resyncKnownRoutesTrigger {
+			rg.resyncKnownRoutes()
 		}
 	}()
 }

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -113,7 +113,7 @@ func (rg *routeGenerator) Start() {
 		}
 
 		// Notify the main client we're in sync now.
-		rg.client.OnInSync(SourceRouteGenerator)
+		rg.client.OnSyncChange(SourceRouteGenerator, true)
 		log.Info("RouteGenerator in sync")
 
 		// Loop waiting for trigger to recheck node-specific routes.

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -124,6 +124,7 @@ func (rg *routeGenerator) Start() {
 }
 
 // Called by the client to trigger us to recheck and advertise or withdraw node-specific routes.
+// Must not block since this is called by the client while it holds its lock.
 func (rg *routeGenerator) TriggerResync() {
 	select {
 	case rg.resyncKnownRoutesTrigger <- struct{}{}:

--- a/pkg/backends/calico/routes_test.go
+++ b/pkg/backends/calico/routes_test.go
@@ -89,7 +89,7 @@ var _ = Describe("RouteGenerator", func() {
 			routeAdvertisementCount: make(map[string]int),
 			client: &client{
 				cache:        make(map[string]string),
-				synced:       true,
+				syncedOnce:   true,
 				clusterCIDRs: []string{"10.0.0.0/16"},
 				externalIPs: []string{
 					ipNet1.String(),

--- a/pkg/backends/calico/routes_test.go
+++ b/pkg/backends/calico/routes_test.go
@@ -87,14 +87,18 @@ var _ = Describe("RouteGenerator", func() {
 			epIndexer:               cache.NewIndexer(cache.MetaNamespaceKeyFunc, nil),
 			svcRouteMap:             make(map[string]map[string]bool),
 			routeAdvertisementCount: make(map[string]int),
-			clusterCIDRs:            []string{"10.0.0.0/16"},
-			externalIPNets: []*net.IPNet{
-				ipNet1,
-				ipNet2,
-			},
 			client: &client{
-				cache:  make(map[string]string),
-				synced: true,
+				cache:        make(map[string]string),
+				synced:       true,
+				clusterCIDRs: []string{"10.0.0.0/16"},
+				externalIPs: []string{
+					ipNet1.String(),
+					ipNet2.String(),
+				},
+				externalIPNets: []*net.IPNet{
+					ipNet1,
+					ipNet2,
+				},
 			},
 		}
 		rg.client.watcherCond = sync.NewCond(&rg.client.cacheLock)
@@ -148,13 +152,13 @@ var _ = Describe("RouteGenerator", func() {
 
 	Describe("onClusterIPsUpdate", func() {
 		It("should do updates only if the new nets are valid", func() {
-			testRouteGeneratorUpdatesOnlyWithValidCIDRs(rg.onClusterIPsUpdate)
+			testRouteGeneratorUpdatesOnlyWithValidCIDRs(rg.client.onClusterIPsUpdate)
 		})
 	})
 
 	Describe("onExternalIPsUpdate", func() {
 		It("should do updates only if the new nets are valid", func() {
-			testRouteGeneratorUpdatesOnlyWithValidCIDRs(rg.onExternalIPsUpdate)
+			testRouteGeneratorUpdatesOnlyWithValidCIDRs(rg.client.onExternalIPsUpdate)
 		})
 	})
 
@@ -409,7 +413,8 @@ var _ = Describe("RouteGenerator", func() {
 		Context("On BGP configuration changes from the syncer", func() {
 			It("should only advertise external IPs within the configured ranges", func() {
 				// Simulate an event from the syncer which sets the External IP range containing the first IP.
-				rg.onExternalIPsUpdate([]string{externalIPRange1})
+				rg.client.onExternalIPsUpdate([]string{externalIPRange1})
+				rg.resyncKnownRoutes()
 
 				// We should now advertise the first external IP, but not the second.
 				Expect(rg.client.cache["/calico/staticroutes/"+externalIP1+"-32"]).To(Equal(externalIP1 + "/32"))
@@ -419,7 +424,8 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(rg.client.cache["/calico/rejectcidrs/"+strings.Replace(externalIPRange1, "/", "-", -1)]).To(Equal(externalIPRange1))
 
 				// Simulate an event from the syncer which updates to use the second range (removing the first)
-				rg.onExternalIPsUpdate([]string{externalIPRange2})
+				rg.client.onExternalIPsUpdate([]string{externalIPRange2})
+				rg.resyncKnownRoutes()
 
 				// We should now advertise the second external IP, but not the first.
 				Expect(rg.client.cache["/calico/staticroutes/"+externalIP1+"-32"]).To(BeEmpty())
@@ -436,7 +442,8 @@ var _ = Describe("RouteGenerator", func() {
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(Equal("127.0.0.1/32"))
 
 				// Withdraw the cluster CIDR from the syncer.
-				rg.onClusterIPsUpdate([]string{})
+				rg.client.onClusterIPsUpdate([]string{})
+				rg.resyncKnownRoutes()
 
 				// We should no longer see cluster CIDRs to be advertised.
 				Expect(rg.client.cache["/calico/staticroutes/127.0.0.1-32"]).To(BeEmpty())


### PR DESCRIPTION
Given a sequence of rapid updates to the config for
`<bgpconfig>.spec.serviceExternalIPs` and
`<bgpconfig>.spec.serviceClusterIPs`, it was possible for the goroutines
handling each update to race with each other, and

- at least, end up in a state where the external and cluster IPs
programmed in confd did not match the final datastore state

- hypothetically, cause other bad effects, from similar goroutines
racing against each other.

To avoid that, this rework keeps the handling of external and cluster
IPs updates entirely within the Calico client object; this means
updates can be handled synchronously without involving the lock of the
separate RouteGenerator object.  It also means that the RouteGenerator
is now responsible only for node-specific routes; this was nearly the
case before, but is now 100% the case.
