### PR TITLE
Remove allocate IP from confd templates and commonize typha connection code

### DIFF
--- a/etc/calico/confd/conf.d/tunl-ip.toml
+++ b/etc/calico/confd/conf.d/tunl-ip.toml
@@ -1,8 +1,0 @@
-[template]
-src = "tunl-ip.template"
-dest = "/tmp/tunl-ip"
-prefix = "/calico/v1/ipam/v4"
-keys = [
-    "/pool",
-]
-reload_cmd = "calico-node -allocate-tunnel-addrs"

--- a/etc/calico/confd/templates/tunl-ip.template
+++ b/etc/calico/confd/templates/tunl-ip.template
@@ -1,8 +1,0 @@
-We must dump all pool data to this file to trigger a re-run of the tunnel
-address allocation code whenever an IP pool changes.
- 
-{{range ls "/pool"}}{{$data := json (getv (printf "/pool/%s" .))}}
-  {{- if or $data.ipip $data.vxlan_mode}}
-    {{- if not $data.disabled}}{{$data}}{{end}}
-  {{- end}}
-{{end}}

--- a/pkg/backends/calico/routes_suite_test.go
+++ b/pkg/backends/calico/routes_suite_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/onsi/ginkgo/reporters"
+
 	"github.com/projectcalico/libcalico-go/lib/testutils"
 )
 


### PR DESCRIPTION
This contains a couple of updates:
-  Remove the confd templates responsible for handling IPIP tunnel allocation. There is a corresponding update to calico/node to use a daemon for handling IPIP tunnel allocations and so we no longer require it in confd.
-  Update confd to use the typha utils code for creating the typha syncer (which was moved from here).
