### PR TITLE
make bgp port number configurable

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -13,6 +13,11 @@ router id {{if eq "hash" ($router_id) -}}
 	{{if ne "" ($router_id)}}{{$router_id}}{{else}}{{$node_ip}}{{end}};
 {{- end}}
 
+{{- $bgp_port := getenv "BGP_PORT" ""}}
+{{- if ne "" ($bgp_port)}}
+listen bgp port {{$bgp_port}};
+{{- end}}
+
 {{- define "LOGGING"}}
 {{- $node_logging_key := printf "/host/%s/loglevel" (getenv "NODENAME")}}
 {{- if exists $node_logging_key}}
@@ -77,6 +82,9 @@ template bgp bgp_template {
 {{- template "LOGGING"}}
   description "Connection to BGP peer";
   local as {{$node_as_num}};
+{{- if ne "" ($bgp_port)}}
+  neighbor port {{$bgp_port}};
+{{- end}}
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream

--- a/etc/calico/confd/templates/bird6.cfg.template
+++ b/etc/calico/confd/templates/bird6.cfg.template
@@ -13,6 +13,11 @@ router id {{if eq "hash" ($router_id) -}}
 	{{if ne "" ($router_id)}}{{$router_id}}{{else}}{{$node_ip}}{{end}};  # Use IPv4 address since router id is 4 octets, even in MP-BGP
 {{- end}}
 
+{{- $bgp_port := getenv "BGP_PORT" ""}}
+{{- if ne "" ($bgp_port)}}
+listen bgp port {{$bgp_port}};
+{{- end}}
+
 {{- define "LOGGING"}}
 {{- $node_logging_key := printf "/host/%s/loglevel" (getenv "NODENAME")}}
 {{- if exists $node_logging_key}}
@@ -77,6 +82,9 @@ template bgp bgp_template {
 {{- template "LOGGING"}}
   description "Connection to BGP peer";
   local as {{$node_as_num}};
+{{- if ne "" ($bgp_port)}}
+  neighbor port {{$bgp_port}};
+{{- end}}
   multihop;
   gateway recursive; # This should be the default, but just in case.
   import all;        # Import all routes, since we don't know what the upstream


### PR DESCRIPTION
We use Calico as the networking plugin in our k8s cluster, meanwhile we also have other applications that run BGP for other purposes, so we need BGP port number configurable to avoid the conflicts.