### PR TITLE
Add support for skipping rendering source address

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -41,6 +41,7 @@ protocol kernel {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
+  merge paths yes;   # Install ECMP routes
   import all;
   export filter calico_kernel_programming; # Default is export none
   graceful restart;  # Turn on graceful restart to reduce potential flaps in

--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -8,6 +8,7 @@ include "bird_ipam.cfg";
 {{- $node_name := getenv "NODENAME"}}
 
 {{- $skip_source_address := getenv "CALICO_SKIP_SOURCE_ADDRESS"}}
+{{- $support_ecmp := getenv "CALICO_SUPPORT_ECMP"}}
 
 router id {{if eq "hash" ($router_id) -}}
 	{{hashToIPv4 $node_name}};
@@ -41,7 +42,9 @@ protocol kernel {
   learn;             # Learn all alien routes from the kernel
   persist;           # Don't remove routes on bird shutdown
   scan time 2;       # Scan kernel routing table every 2 seconds
+  {{- if ne $support_ecmp ""}}
   merge paths yes;   # Install ECMP routes
+  {{- end}}
   import all;
   export filter calico_kernel_programming; # Default is export none
   graceful restart;  # Turn on graceful restart to reduce potential flaps in

--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -7,6 +7,8 @@ include "bird_ipam.cfg";
 
 {{- $node_name := getenv "NODENAME"}}
 
+{{- $skip_source_address := getenv "CALICO_SKIP_SOURCE_ADDRESS"}}
+
 router id {{if eq "hash" ($router_id) -}}
 	{{hashToIPv4 $node_name}};
 {{- else -}}
@@ -82,7 +84,9 @@ template bgp bgp_template {
   import all;        # Import all routes, since we don't know what the upstream
                      # topology is and therefore have to trust the ToR/RR.
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
+  {{- if ne $skip_source_address ""}}
   source address {{$node_ip}};  # The local address we use for the TCP connection
+  {{- end}}
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;

--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -85,7 +85,7 @@ template bgp bgp_template {
   import all;        # Import all routes, since we don't know what the upstream
                      # topology is and therefore have to trust the ToR/RR.
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
-  {{- if ne $skip_source_address ""}}
+  {{- if eq $skip_source_address ""}}
   source address {{$node_ip}};  # The local address we use for the TCP connection
   {{- end}}
   add paths on;


### PR DESCRIPTION
The source address will not be rendered into config file in case the CALICO_SKIP_SOURCE_ADDRESS environment variable is defined.
Also, ECMP support can be enabled in BIRD by setting CALICO_SUPPORT_ECMP variable. 
If those variables are not defined there will be no changes in current behavior. 
This should at least partially address the issue reported here: https://github.com/projectcalico/confd/issues/328 and here: https://github.com/projectcalico/calico/issues/1829