### PR TITLE
Use sv instead of pkill to send hup to bird.

### DIFF
--- a/etc/calico/confd/conf.d/bird.toml
+++ b/etc/calico/confd/conf.d/bird.toml
@@ -7,4 +7,4 @@ keys = [
     "/global",
 ]
 check_cmd = "bird -p -c {{.src}}"
-reload_cmd = "pkill -HUP bird || true"
+reload_cmd = "sv hup bird || true"

--- a/etc/calico/confd/conf.d/bird6.toml
+++ b/etc/calico/confd/conf.d/bird6.toml
@@ -7,4 +7,4 @@ keys = [
     "/global",
 ]
 check_cmd = "bird6 -p -c {{.src}}"
-reload_cmd = "pkill -HUP bird6 || true"
+reload_cmd = "sv hup bird6 || true"

--- a/etc/calico/confd/conf.d/bird6_aggr.toml
+++ b/etc/calico/confd/conf.d/bird6_aggr.toml
@@ -5,4 +5,4 @@ keys = [
     "/calico/ipam/v2/host//NODENAME/ipv6/block",
     "/calico/staticroutesv6",
 ]
-reload_cmd = "pkill -HUP bird6 || true"
+reload_cmd = "sv hup bird6 || true"

--- a/etc/calico/confd/conf.d/bird6_ipam.toml
+++ b/etc/calico/confd/conf.d/bird6_ipam.toml
@@ -7,4 +7,4 @@ keys = [
     "/staticroutesv6",
     "/rejectcidrsv6",
 ]
-reload_cmd = "pkill -HUP bird6 || true"
+reload_cmd = "sv hup bird6 || true"

--- a/etc/calico/confd/conf.d/bird_aggr.toml
+++ b/etc/calico/confd/conf.d/bird_aggr.toml
@@ -5,4 +5,4 @@ keys = [
     "/calico/ipam/v2/host//NODENAME/ipv4/block",
     "/calico/staticroutes",
 ]
-reload_cmd = "pkill -HUP bird || true"
+reload_cmd = "sv hup bird || true"

--- a/etc/calico/confd/conf.d/bird_ipam.toml
+++ b/etc/calico/confd/conf.d/bird_ipam.toml
@@ -8,4 +8,4 @@ keys = [
     "/staticroutes",
     "/rejectcidrs",
 ]
-reload_cmd = "pkill -HUP bird || true"
+reload_cmd = "sv hup bird || true"


### PR DESCRIPTION
pkill is no longer available in the node image (to reduce surface for CVEs) so switch to using the service manager instead.