### PR TITLE
add AS_PATH based rule to BGP export filter

### DIFF
--- a/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -8,7 +8,7 @@ filter calico_export_to_bgp_peers {
   {{- range ls $static_key}}
     {{- $parts := split . "-"}}
     {{- $cidr := join $parts "/"}}
-  if ( net ~ {{$cidr}} ) then { accept; }
+  if ( net ~ {{$cidr}} ) && ( bgp_path.len = 1 ) then { accept; }
   {{- end}}
 {{- end}}
 {{range ls "/v1/ipam/v4/pool"}}{{$data := json (getv (printf "/v1/ipam/v4/pool/%s" .))}}

--- a/etc/calico/confd/templates/bird_ipam.cfg.template
+++ b/etc/calico/confd/templates/bird_ipam.cfg.template
@@ -12,7 +12,7 @@ filter calico_export_to_bgp_peers {
   {{- end}}
 {{- end}}
 {{range ls "/v1/ipam/v4/pool"}}{{$data := json (getv (printf "/v1/ipam/v4/pool/%s" .))}}
-  if ( net ~ {{$data.cidr}} ) then {
+  if ( net ~ {{$data.cidr}} ) && ( bgp_path.len = 1 ) then {
     accept;
   }
 {{- end}}


### PR DESCRIPTION
On some environment (e.x. [The AS per Compute Server model](https://docs.projectcalico.org/reference/architecture/design/l3-interconnect-fabric#the-as-per-compute-server-model) + AS per redundant ToR ) , additional AS_PATH based validation rule(`bgp_path.len = 1`) is required on `calico_export_to_bgp_peers`.  

This additional rule doesn't affect another environment(iBGP, full mesh, and so on).

Issue on default template is below diagram.
![calico_bgp_export_filter](https://user-images.githubusercontent.com/8026416/86559380-c63b5c00-bf96-11ea-8f91-e6791a6fca71.png)
