### PR TITLE
Avoid duplicate communities in BIRD 

### DIFF
--- a/tests/mock_data/calicoctl/mesh/communities/input.yaml
+++ b/tests/mock_data/calicoctl/mesh/communities/input.yaml
@@ -18,6 +18,7 @@ spec:
     - cidr: fd00:96::/112
       communities:
       - bgp-comm-large
+      - bgp-comm-large
   listenPort: 177
 
 ---

--- a/tests/mock_data/calicoctl/mesh/communities/step2/input.yaml
+++ b/tests/mock_data/calicoctl/mesh/communities/step2/input.yaml
@@ -12,6 +12,7 @@ spec:
       communities:
       - 5663:12  
       - bgp-comm-large
+      - 5663:12
     - cidr: fd00:96::/112
       communities:
       - bgp-comm-large

--- a/tests/test_suite_common.sh
+++ b/tests/test_suite_common.sh
@@ -481,7 +481,10 @@ compare_templates() {
         fi
         expected=/tests/compiled_templates/${testdir}/${f}
         actual=/etc/calico/confd/config/${f}
-        if ! diff --ignore-blank-lines -q ${expected} ${actual} 1>/dev/null 2>&1; then
+        
+        # Order of line in templates is not guaranteed for communities test, so sort and compare
+        if [[ $(diff --ignore-blank-lines -q ${expected} ${actual}) != "" ]] \
+          && [[ "${testdir}" != *"mesh/communities"* || $(diff <(sort ${expected}) <(sort ${actual})) != "" ]] ; then       
             if ! $record; then
                 rc=1;
             fi


### PR DESCRIPTION
If duplicate communities are set, bird.cfg has duplicate entries within `apply_communities` function, so it might cause some confusion for a user. BIRD appears to do the right thing and ignore duplicates. This PR is to remove setting duplicate entries in bird.cfg

For instance, if duplicate communities are set as,
```
spec:
  communities:
  - name: bgp-large-community
    value: 63400:300:100
  - name: bgp-large-community-2
    value: 63400:300:100
  prefixAdvertisements:
  - cidr: 192.168.0.0/16
    communities:
    - bgp-large-community
    - bgp-large-community-2
```
bird.cfg now includes the duplicates
```
function apply_communities ()
{
      if ( net ~ 192.168.0.0/16 ) then {
          bgp_large_community.add((63400, 300, 100));
          bgp_large_community.add((63400, 300, 100));
      }
}
...
```
Checking in BRID itself we see that the duplicate is ignored. 
```
1007-192.168.3.128/26   via 10.128.0.1 on ens4 [Mesh_10_128_0_2 01:00:29 from 10.128.0.2] * (100/?) [i]
1008-	Type: BGP unicast univ
1012-	BGP.origin: IGP
     	BGP.as_path:
     	BGP.next_hop: 10.128.0.2
     	BGP.local_pref: 100
     	BGP.large_community: (63400, 300, 100)
```