### PR TITLE
Export multipath route to kernel on ipv4 and ipv6

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -85,6 +85,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/etc/calico/confd/templates/bird6.cfg.template
+++ b/etc/calico/confd/templates/bird6.cfg.template
@@ -86,6 +86,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/global/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/global/bird.cfg
@@ -23,6 +23,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/global/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/global/bird6.cfg
@@ -22,6 +22,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/keepnexthop-global/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/keepnexthop-global/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/keepnexthop-global/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/keepnexthop-global/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/keepnexthop/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/keepnexthop/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/keepnexthop/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/keepnexthop/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/route_reflector/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/route_reflector/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/selectors/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/selectors/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/selectors/step2/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/step2/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/selectors/step2/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/step2/bird6.cfg
@@ -20,6 +20,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/specific_node/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/specific_node/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/explicit_peering/specific_node/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/specific_node/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/communities/bird.cfg
+++ b/tests/compiled_templates/mesh/communities/bird.cfg
@@ -28,6 +28,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/communities/bird6.cfg
+++ b/tests/compiled_templates/mesh/communities/bird6.cfg
@@ -25,6 +25,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/communities/step2/bird.cfg
+++ b/tests/compiled_templates/mesh/communities/step2/bird.cfg
@@ -27,6 +27,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/communities/step2/bird6.cfg
+++ b/tests/compiled_templates/mesh/communities/step2/bird6.cfg
@@ -26,6 +26,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/hash/bird.cfg
+++ b/tests/compiled_templates/mesh/hash/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/hash/bird6.cfg
+++ b/tests/compiled_templates/mesh/hash/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/ipip-always/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-always/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/ipip-always/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-always/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/ipip-cross-subnet/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-cross-subnet/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/ipip-cross-subnet/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-cross-subnet/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/ipip-off/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-off/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/ipip-off/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-off/bird6.cfg
@@ -20,6 +20,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/static-routes/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/static-routes/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/static-routes/step2/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes/step2/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/static-routes/step2/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes/step2/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/vxlan-always/bird.cfg
+++ b/tests/compiled_templates/mesh/vxlan-always/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
+++ b/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password-deadlock/bird.cfg
+++ b/tests/compiled_templates/password-deadlock/bird.cfg
@@ -22,6 +22,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password-deadlock/bird6.cfg
+++ b/tests/compiled_templates/password-deadlock/bird6.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step1/bird.cfg
+++ b/tests/compiled_templates/password/step1/bird.cfg
@@ -22,6 +22,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step1/bird6.cfg
+++ b/tests/compiled_templates/password/step1/bird6.cfg
@@ -20,6 +20,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step2/bird.cfg
+++ b/tests/compiled_templates/password/step2/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step2/bird6.cfg
+++ b/tests/compiled_templates/password/step2/bird6.cfg
@@ -20,6 +20,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step3/bird.cfg
+++ b/tests/compiled_templates/password/step3/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step3/bird6.cfg
+++ b/tests/compiled_templates/password/step3/bird6.cfg
@@ -20,6 +20,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step4/bird.cfg
+++ b/tests/compiled_templates/password/step4/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step4/bird6.cfg
+++ b/tests/compiled_templates/password/step4/bird6.cfg
@@ -20,6 +20,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step5/bird.cfg
+++ b/tests/compiled_templates/password/step5/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step5/bird6.cfg
+++ b/tests/compiled_templates/password/step5/bird6.cfg
@@ -20,6 +20,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step6/bird.cfg
+++ b/tests/compiled_templates/password/step6/bird.cfg
@@ -21,6 +21,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.

--- a/tests/compiled_templates/password/step6/bird6.cfg
+++ b/tests/compiled_templates/password/step6/bird6.cfg
@@ -20,6 +20,7 @@ protocol kernel {
                      # flapping since multiple nodes update their BGP
                      # configuration at the same time, GR is not guaranteed to
                      # work correctly in this scenario.
+  merge paths on;    # Allow export multipath routes (ECMP)
 }
 
 # Watch interface up/down events.


### PR DESCRIPTION
Allow ECMP egress gw propagation to kernel.
Actual behavior that bird sees the received multipath routes (e.g. default routes 0.0.0.0/0)
but exports only one path to the kernel not all paths.

### Description

See also: projectcalico/calico#4114
