### PR TITLE
Advertise Load Balancer IPs like External IPs

### DIFF
--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -249,6 +249,20 @@ func (rg *routeGenerator) getAllRoutesForService(svc *v1.Service) []string {
 		}
 	}
 
+	if svc.Status.LoadBalancer.Ingress != nil {
+		for _, lbIngress := range svc.Status.LoadBalancer.Ingress {
+			if len(lbIngress.IP) > 0 {
+				if !rg.isAllowedExternalIP(lbIngress.IP) {
+					svc := fmt.Sprintf("%s/%s", svc.Namespace, svc.Name)
+					log.WithFields(log.Fields{"ip": lbIngress.IP, "svc": svc}).Info("Cannot advertise LoadBalancer IP - not whitelisted")
+					continue
+				}
+				routes = append(routes, lbIngress.IP)
+			}
+		}
+
+	}
+
 	return addFullIPLength(routes)
 }
 


### PR DESCRIPTION
MetalLB can currently not be used with Calico as it sets a `LoadBalancer` Ingress IP instead of an External IP. By advertising Ingress IPs as well as External IPs MetalLB can work with Calico without additional BGP peers.

The linked issue suggests enabling this functionality with a config flag. I'm happy to implement that with some pointers on how to add one.

Tested in production. A `calico-node` image based on 3.16 can be pulled at: `salanki/calico:node-advertiselb`

Fixes: https://github.com/projectcalico/confd/issues/301
Fixes: https://github.com/metallb/metallb/issues/114