### PR TITLE
Update pins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/kelseyhightower/memkv v0.1.1
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0
-	github.com/projectcalico/libcalico-go v1.7.2-0.20201006092128-6c4ea9eb1b45
-	github.com/projectcalico/typha v0.7.3-0.20201006115548-e273ebcc2f98
+	github.com/projectcalico/libcalico-go v1.7.2-0.20201030225844-6b3cd568a038
+	github.com/projectcalico/typha v0.7.3-0.20201104224511-fe7566e58e70
 	github.com/sirupsen/logrus v1.4.2
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -216,12 +216,12 @@ github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba h1:aaF2byUCZ
 github.com/projectcalico/go-json v0.0.0-20161128004156-6219dc7339ba/go.mod h1:q8EdCgBdMQzgiX/uk4GXLWLk+gIHd1a7mWUAamJKDb4=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54 h1:Jt2Pic9dxgJisekm8q2WV9FaWxUJhhRfwHSP640drww=
 github.com/projectcalico/go-yaml-wrapper v0.0.0-20191112210931-090425220c54/go.mod h1:UgC0aTQ2KMDxlX3lU/stndk7DMUBJqzN40yFiILHgxc=
-github.com/projectcalico/libcalico-go v1.7.2-0.20201006092128-6c4ea9eb1b45 h1:t0zrKC138wIUcSSGamJX6V/+deAjwwz6j5iRDhtxb04=
-github.com/projectcalico/libcalico-go v1.7.2-0.20201006092128-6c4ea9eb1b45/go.mod h1:+HQmSvCZc2MCvkgOm1tn0zAkpJikDhvhcRcAiavLYtg=
+github.com/projectcalico/libcalico-go v1.7.2-0.20201030225844-6b3cd568a038 h1:VdlUZoTA8KVyqBeM/CLx6h82KcgE13ynYIcfnxPsyC0=
+github.com/projectcalico/libcalico-go v1.7.2-0.20201030225844-6b3cd568a038/go.mod h1:+HQmSvCZc2MCvkgOm1tn0zAkpJikDhvhcRcAiavLYtg=
 github.com/projectcalico/logrus v1.0.4-calico h1:bHJ2KLGTFzoWpRISe13CO7HVxxrKunDjyUz/wFiBY8c=
 github.com/projectcalico/logrus v1.0.4-calico/go.mod h1:DfgrchabbtEO9wjOz5lVae+XRvjFKKWEA9GTMme6A8g=
-github.com/projectcalico/typha v0.7.3-0.20201006115548-e273ebcc2f98 h1:7w01Ei5RFSG3n/huRyZ9qrhYseXGupVyNdzS8tZsyaI=
-github.com/projectcalico/typha v0.7.3-0.20201006115548-e273ebcc2f98/go.mod h1:PtA60zJ0sOt+xfp+grMMcu57rVLQezXFrhdzZNAO3yQ=
+github.com/projectcalico/typha v0.7.3-0.20201104224511-fe7566e58e70 h1:EdGFmIq+i1XzzovGf9uLFEaJS7xJCNuFTWbPDQJcd2A=
+github.com/projectcalico/typha v0.7.3-0.20201104224511-fe7566e58e70/go.mod h1:4S3QG/nzlY/p46OaZP3z5n2YloHJ6RpF22To4etgFAU=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=


### PR DESCRIPTION
https://github.com/projectcalico/libcalico-go/tree/release-v3.16
https://github.com/projectcalico/typha/tree/release-v3.16