### PR TITLE
Not mesh BGPPeering via secondary interfaces.

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -121,7 +121,6 @@ template bgp bgp_template {
   import all;        # Import all routes, since we don't know what the upstream
                      # topology is and therefore have to trust the ToR/RR.
   export filter calico_export_to_bgp_peers;  # Only want to export routes for workloads.
-  source address {{$node_ip}};  # The local address we use for the TCP connection
   add paths on;
   graceful restart;  # See comment in kernel section about graceful restart.
   connect delay time 2;
@@ -147,6 +146,7 @@ template bgp bgp_template {
 # For peer {{$onode_ip_key}}
 {{if eq $onode_ip ($node_ip) }}# Skipping ourselves ({{$node_ip}})
 {{else if ne "" $onode_ip}}protocol bgp Mesh_{{$id}} from bgp_template {
+  source address {{$node_ip}};  # The local address we use for the TCP connection
   neighbor {{$onode_ip}} {{if ne "" $listen_port}}port {{$listen_port}} {{end}}as {{if exists $onode_as_key}}{{getv $onode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
   {{- /*
        Make the peering unidirectional. This avoids a race where


### PR DESCRIPTION
Not mesh BGPPeer's can be established using another interface than primary (Calico autodetected). In this case, BIRD will use the address of the local end of the interface our neighbor is connected to.