### PR TITLE
Revert test diff loosening, now that community values are sorted

### DIFF
--- a/tests/test_suite_common.sh
+++ b/tests/test_suite_common.sh
@@ -790,10 +790,7 @@ compare_templates() {
         fi
         expected=/tests/compiled_templates/${testdir}/${f}
         actual=/etc/calico/confd/config/${f}
-
-        # Order of line in templates is not guaranteed for communities test, so sort and compare
-        if [[ $(diff --ignore-blank-lines -q ${expected} ${actual}) != "" ]] \
-          && [[ "${testdir}" != *"mesh/communities"* || $(diff <(sort ${expected}) <(sort ${actual})) != "" ]] ; then
+        if ! diff --ignore-blank-lines -q ${expected} ${actual} 1>/dev/null 2>&1; then
             if ! $record; then
                 rc=1;
             fi


### PR DESCRIPTION
I came to this accidentally, but I'm concerned that the loosening of
the template comparison here was too general, and a bit risky, and
it's much better to revert back to a normal diff.

The accident was:

- In porting the BGPPeer source address to OSS, the mesh/communities
test was failing for me, and the diff showed that the BGP community
lines were in the wrong order.

- I realize now that that's NOT why the test was failing; it was
failing because of another diff further down in the file.  However, at
the time, I thought this ordering was a non-determinism problem, and
addressed it by sorting the community values in client.go.

Now that we have the community values sorted, we can revert the
loosening that was briefly introduced here.