### PR TITLE
Advertise LoadBalancer IPs

### DIFF
--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -249,6 +249,20 @@ func (rg *routeGenerator) getAllRoutesForService(svc *v1.Service) []string {
 		}
 	}
 
+	if svc.Status.LoadBalancer.Ingress != nil {
+		for _, lbIngress := range svc.Status.LoadBalancer.Ingress {
+			if len(lbIngress.IP) > 0 {
+				if !rg.isAllowedExternalIP(lbIngress.IP) {
+					svc := fmt.Sprintf("%s/%s", svc.Namespace, svc.Name)
+					log.WithFields(log.Fields{"ip": lbIngress.IP, "svc": svc}).Info("Cannot advertise LoadBalancer IP - not whitelisted")
+					continue
+				}
+				routes = append(routes, lbIngress.IP)
+			}
+		}
+
+	}
+
 	return addFullIPLength(routes)
 }
 

--- a/pkg/backends/calico/routes.go
+++ b/pkg/backends/calico/routes.go
@@ -236,13 +236,13 @@ func (rg *routeGenerator) getAllRoutesForService(svc *v1.Service) []string {
 		// Only advertise cluster IPs if we've been told to.
 		routes = append(routes, svc.Spec.ClusterIP)
 	}
+	svcID := fmt.Sprintf("%s/%s", svc.Namespace, svc.Name)
 
 	if svc.Spec.ExternalIPs != nil {
 		for _, externalIP := range svc.Spec.ExternalIPs {
 			// Only advertise whitelisted external IPs
 			if !rg.isAllowedExternalIP(externalIP) {
-				svc := fmt.Sprintf("%s/%s", svc.Namespace, svc.Name)
-				log.WithFields(log.Fields{"ip": externalIP, "svc": svc}).Info("Cannot advertise External IP - not whitelisted")
+				log.WithFields(log.Fields{"ip": externalIP, "svc": svcID}).Info("Cannot advertise External IP - not whitelisted")
 				continue
 			}
 			routes = append(routes, externalIP)
@@ -252,9 +252,9 @@ func (rg *routeGenerator) getAllRoutesForService(svc *v1.Service) []string {
 	if svc.Status.LoadBalancer.Ingress != nil {
 		for _, lbIngress := range svc.Status.LoadBalancer.Ingress {
 			if len(lbIngress.IP) > 0 {
-				if !rg.isAllowedExternalIP(lbIngress.IP) {
-					svc := fmt.Sprintf("%s/%s", svc.Namespace, svc.Name)
-					log.WithFields(log.Fields{"ip": lbIngress.IP, "svc": svc}).Info("Cannot advertise LoadBalancer IP - not whitelisted")
+				// Only advertise whitelisted LB IPs
+				if !rg.isAllowedLoadBalancerIP(lbIngress.IP) {
+					log.WithFields(log.Fields{"ip": lbIngress.IP, "svc": svcID}).Info("Cannot advertise LoadBalancer IP - not whitelisted")
 					continue
 				}
 				routes = append(routes, lbIngress.IP)
@@ -331,7 +331,26 @@ func (rg *routeGenerator) isAllowedExternalIP(externalIP string) bool {
 
 	// Guilty until proven innocent
 	return false
+}
 
+// isAllowedLoadBalancerIP determines if the given IP is in the list of
+// whitelisted LoadBalancer CIDRs given in the default bgpconfiguration.
+func (rg *routeGenerator) isAllowedLoadBalancerIP(loadBalancerIP string) bool {
+
+	ip := net.ParseIP(loadBalancerIP)
+	if ip == nil {
+		log.Errorf("Could not parse service LB IP: %s", loadBalancerIP)
+		return false
+	}
+
+	for _, allowedNet := range rg.client.GetLoadBalancerIPs() {
+		if allowedNet.Contains(ip) {
+			return true
+		}
+	}
+
+	// Guilty until proven innocent
+	return false
 }
 
 // addFullIPLength returns a new slice, with the full IP length appended onto every item.

--- a/tests/compiled_templates/mesh/static-routes/bird_aggr.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird_aggr.cfg
@@ -10,6 +10,7 @@ protocol static {
    # Static routes.
    route 10.101.0.0/16 blackhole;
    route 10.101.0.101/32 blackhole;
+   route 80.15.0.0/24 blackhole;
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes/bird_ipam.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird_ipam.cfg
@@ -7,6 +7,7 @@ filter calico_export_to_bgp_peers {
   # Export static routes.
   if ( net ~ 10.101.0.0/16 ) then { accept; }
   if ( net ~ 10.101.0.101/32 ) then { accept; }
+  if ( net ~ 80.15.0.0/24 ) then { accept; }
 
   if ( net ~ 192.168.0.0/16 ) then {
     accept;
@@ -19,6 +20,7 @@ filter calico_kernel_programming {
 
   # Don't program static routes into kernel.
   if ( net ~ 10.101.0.0/16 ) then { reject; }
+  if ( net ~ 80.15.0.0/24 ) then { reject; }
 
   if ( net ~ 192.168.0.0/16 ) then {
     krt_tunnel = "tunl0";

--- a/tests/mock_data/calicoctl/mesh/static-routes/input.yaml
+++ b/tests/mock_data/calicoctl/mesh/static-routes/input.yaml
@@ -6,6 +6,8 @@ spec:
   serviceClusterIPs:
   - cidr: 10.101.0.0/16
   - cidr: fd00:96::/112
+  serviceLoadBalancerIPs:
+  - cidr: 80.15.0.0/24
 
 ---
 

--- a/tests/mock_data/calicoctl/mesh/static-routes/kubectl-input.yaml
+++ b/tests/mock_data/calicoctl/mesh/static-routes/kubectl-input.yaml
@@ -12,6 +12,16 @@ spec:
   - port: 80
     protocol: TCP
     targetPort: 80
+status:
+ # TODO: kubectl doesn't support writing status, so these IPs
+ # never make it to the apiserver. Need changes to our test rig
+ # to support this.
+ loadBalancer:
+   ingress:
+   # Within the range in BGP config.
+   - ip: 80.15.0.1/32
+   # Not within the range in BGP config.
+   - ip: 90.15.0.1/32
 
 ---
 


### PR DESCRIPTION
Thanks to @salanki for starting this work here: https://github.com/projectcalico/confd/pull/385

This works much the same as our ClusterIP / ExternalIP advertisement.
- Advertise each range provided in the BGP configuration from every node.
- Advertise LoadBalancer IP addresses for services with `externalTrafficPolicy: Local` from nodes with local endpoints.
- Only advertise those IPs if they are within a configured range on the BGP config. 

```release-note
Ability to advertise LoadBalancer IPs over BGP
```