### PR TITLE
Allow enabling bfd protocol conditionally

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -109,6 +109,22 @@ protocol direct {
 
 {{if eq "" ($node_ip)}}# IPv4 disabled on this node.
 {{else}}{{$node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
+
+{{- $bfd := getenv "ENABLE_BFD" "false" }}
+{{- if eq $bfd "true" }}
+# Enable BFD protocol
+protocol bfd {
+    interface -"cali*", -"kube-ipvs*", "*" {
+        interval 300 ms;
+        multiplier 3;
+    };
+    multihop {
+        interval 300 ms;
+        multiplier 3;
+    };
+}
+{{- end }}
+
 # Template for all BGP clients
 template bgp bgp_template {
 {{- $as_key := or (and (exists $node_as_key) $node_as_key) "/global/as_num"}}
@@ -126,7 +142,11 @@ template bgp bgp_template {
   connect delay time 2;
   connect retry time 5;
   error wait time 5,30;
+  {{- if eq $bfd "true" }}
+  bfd yes;
+  {{- end }}
 }
+
 
 # ------------- Node-to-node mesh -------------
 {{- $node_cid_key := printf "/host/%s/rr_cluster_id" (getenv "NODENAME")}}

--- a/etc/calico/confd/templates/bird6.cfg.template
+++ b/etc/calico/confd/templates/bird6.cfg.template
@@ -110,6 +110,22 @@ protocol direct {
 
 {{if eq "" ($node_ip6)}}# IPv6 disabled on this node.
 {{else}}{{$node_as_key := printf "/host/%s/as_num" (getenv "NODENAME")}}
+
+{{- $bfd := getenv "ENABLE_BFD" "false" }}
+{{- if eq $bfd "true" }}
+# Enable BFD protocol
+protocol bfd {
+    interface -"cali*", -"kube-ipvs*", "*" {
+        interval 300 ms;
+        multiplier 3;
+    };
+    multihop {
+        interval 300 ms;
+        multiplier 3;
+    };
+}
+{{- end }}
+
 # Template for all BGP clients
 template bgp bgp_template {
 {{- $as_key := or (and (exists $node_as_key) $node_as_key) "/global/as_num"}}
@@ -127,6 +143,9 @@ template bgp bgp_template {
   connect delay time 2;
   connect retry time 5;
   error wait time 5,30;
+  {{- if eq $bfd "true" }}
+  bfd yes;
+  {{- end }}
 }
 
 # ------------- Node-to-node mesh -------------


### PR DESCRIPTION
Why:
The entire rationale is described in [projectcalico/calico #4607](https://github.com/projectcalico/calico/issues/4607)
but the TL;DR is that for allowing quick recovery of BGP kubernetes
service ips in the case of a complete node failure, we need to allow BFD
in calico's bird component.

What:
Add 2 if clause statements, one for enabling the bfd protocol with some
defaults and one for enabling bfd in the bgp_template. The trigger for
enabling this is an environmental variable called ENABLE_BFD.