### PR TITLE
Skip tap/qbr/qvo ports

### DIFF
--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -106,7 +106,6 @@ protocol direct {
        for it's networking so when deploying Calico side-by-side an OpenStack
        cloud then there will be a lot of those interfaces.
   */ -}}
-  # 
 }
 
 {{if eq "" ($node_ip)}}# IPv4 disabled on this node.

--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -96,15 +96,17 @@ protocol device {
 
 protocol direct {
 {{- template "LOGGING"}}
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for it's networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
+  # 
 }
 
 {{if eq "" ($node_ip)}}# IPv4 disabled on this node.

--- a/etc/calico/confd/templates/bird.cfg.template
+++ b/etc/calico/confd/templates/bird.cfg.template
@@ -103,7 +103,7 @@ protocol direct {
        kube-ipvs0 because this interface gets an address for every in use
        cluster IP. We use static routes for when we legitimately want to
        export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
-       for it's networking so when deploying Calico side-by-side an OpenStack
+       for its networking so when deploying Calico side-by-side an OpenStack
        cloud then there will be a lot of those interfaces.
   */ -}}
 }

--- a/etc/calico/confd/templates/bird6.cfg.template
+++ b/etc/calico/confd/templates/bird6.cfg.template
@@ -97,15 +97,16 @@ protocol device {
 
 protocol direct {
 {{- template "LOGGING"}}
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 {{if eq "" ($node_ip6)}}# IPv6 disabled on this node.

--- a/tests/compiled_templates/explicit_peering/global/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/global/bird.cfg
@@ -34,15 +34,16 @@ protocol device {
 
 protocol direct {
   debug all;
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/global/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/global/bird6.cfg
@@ -33,15 +33,16 @@ protocol device {
 
 protocol direct {
   debug all;
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/explicit_peering/keepnexthop-global/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/keepnexthop-global/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/keepnexthop-global/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/keepnexthop-global/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/keepnexthop/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/keepnexthop/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/keepnexthop/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/keepnexthop/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/route_reflector/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/route_reflector/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/route_reflector/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/selectors/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/selectors/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/selectors/step2/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/step2/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/selectors/step2/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/selectors/step2/bird6.cfg
@@ -31,15 +31,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/specific_node/bird.cfg
+++ b/tests/compiled_templates/explicit_peering/specific_node/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/explicit_peering/specific_node/bird6.cfg
+++ b/tests/compiled_templates/explicit_peering/specific_node/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/communities/bird.cfg
+++ b/tests/compiled_templates/mesh/communities/bird.cfg
@@ -39,15 +39,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/communities/bird6.cfg
+++ b/tests/compiled_templates/mesh/communities/bird6.cfg
@@ -36,15 +36,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/communities/step2/bird.cfg
+++ b/tests/compiled_templates/mesh/communities/step2/bird.cfg
@@ -38,15 +38,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/communities/step2/bird6.cfg
+++ b/tests/compiled_templates/mesh/communities/step2/bird6.cfg
@@ -37,15 +37,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/hash/bird.cfg
+++ b/tests/compiled_templates/mesh/hash/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/hash/bird6.cfg
+++ b/tests/compiled_templates/mesh/hash/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/ipip-always/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-always/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/ipip-always/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-always/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/ipip-cross-subnet/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-cross-subnet/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/ipip-cross-subnet/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-cross-subnet/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/ipip-off/bird.cfg
+++ b/tests/compiled_templates/mesh/ipip-off/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/ipip-off/bird6.cfg
+++ b/tests/compiled_templates/mesh/ipip-off/bird6.cfg
@@ -31,15 +31,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes-exclude-node/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes-exclude-node/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes-exclude-node/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes-exclude-node/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes-exclude-node/step2/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv4 disabled on this node.

--- a/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes-no-ipv4-address/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/mesh/static-routes/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes/step2/bird.cfg
+++ b/tests/compiled_templates/mesh/static-routes/step2/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/static-routes/step2/bird6.cfg
+++ b/tests/compiled_templates/mesh/static-routes/step2/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/vxlan-always/bird.cfg
+++ b/tests/compiled_templates/mesh/vxlan-always/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
+++ b/tests/compiled_templates/mesh/vxlan-always/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/password-deadlock/bird.cfg
+++ b/tests/compiled_templates/password-deadlock/bird.cfg
@@ -33,15 +33,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/password-deadlock/bird6.cfg
+++ b/tests/compiled_templates/password-deadlock/bird6.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/password/step1/bird.cfg
+++ b/tests/compiled_templates/password/step1/bird.cfg
@@ -33,15 +33,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/password/step1/bird6.cfg
+++ b/tests/compiled_templates/password/step1/bird6.cfg
@@ -31,15 +31,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/password/step2/bird.cfg
+++ b/tests/compiled_templates/password/step2/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/password/step2/bird6.cfg
+++ b/tests/compiled_templates/password/step2/bird6.cfg
@@ -31,15 +31,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/password/step3/bird.cfg
+++ b/tests/compiled_templates/password/step3/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/password/step3/bird6.cfg
+++ b/tests/compiled_templates/password/step3/bird6.cfg
@@ -31,15 +31,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/password/step4/bird.cfg
+++ b/tests/compiled_templates/password/step4/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/password/step4/bird6.cfg
+++ b/tests/compiled_templates/password/step4/bird6.cfg
@@ -31,15 +31,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/password/step5/bird.cfg
+++ b/tests/compiled_templates/password/step5/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/password/step5/bird6.cfg
+++ b/tests/compiled_templates/password/step5/bird6.cfg
@@ -31,15 +31,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.

--- a/tests/compiled_templates/password/step6/bird.cfg
+++ b/tests/compiled_templates/password/step6/bird.cfg
@@ -32,15 +32,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 

--- a/tests/compiled_templates/password/step6/bird6.cfg
+++ b/tests/compiled_templates/password/step6/bird6.cfg
@@ -31,15 +31,16 @@ protocol device {
 
 protocol direct {
   debug { states };
-  interface -"cali*", -"kube-ipvs*", "*"; # Exclude cali* and kube-ipvs* but
-                                          # include everything else.  In
-                                          # IPVS-mode, kube-proxy creates a
-                                          # kube-ipvs0 interface. We exclude
-                                          # kube-ipvs0 because this interface
-                                          # gets an address for every in use
-                                          # cluster IP. We use static routes
-                                          # for when we legitimately want to
-                                          # export cluster IPs.
+  interface -"cali*", -"kube-ipvs*", -"tap*", -"qvo*", -"qvb*", "*";
+  {{- /*
+       Exclude cali* and kube-ipvs* but include everything else.  In
+       IPVS-mode, kube-proxy creates a kube-ipvs0 interface. We exclude
+       kube-ipvs0 because this interface gets an address for every in use
+       cluster IP. We use static routes for when we legitimately want to
+       export cluster IPs.  In addition, OpenStack nodes use tap*/qvo*/qvb*
+       for its networking so when deploying Calico side-by-side an OpenStack
+       cloud then there will be a lot of those interfaces.
+  */ -}}
 }
 
 # IPv6 disabled on this node.


### PR DESCRIPTION
The tap/qbr/qvo ports are not needed and they are local only ports that are used
inside OpenStack for wiring up VMs.  In hypervisors with many VMs that are also
running Calico (not Calico for OpenStack, just a Kubernetes cluster that uses is
on the same infra), the CPU usage becomes very high for bird because of this.