### PR TITLE
fix: allow ip ranges

### DIFF
--- a/pkg/resource/template/template_funcs.go
+++ b/pkg/resource/template/template_funcs.go
@@ -55,7 +55,12 @@ func hashToIPv4(nodeName string) string {
 	}
 	hashBytes := hash.Sum(nil)
 	ip := hashBytes[:4]
-	routerId := strconv.Itoa(int(ip[0])) + "." +
+	//BGP doesn't allow router IDs in special IP ranges (e.g., 224.x.x.x)
+	ip0Value := int(ip[0])
+	if ip0Value > 223 {
+		ip0Value = ip0Value - 32
+	}
+	routerId := strconv.Itoa(ip0Value) + "." +
 		strconv.Itoa(int(ip[1])) + "." +
 		strconv.Itoa(int(ip[2])) + "." +
 		strconv.Itoa(int(ip[3]))


### PR DESCRIPTION
Allow unicast ip addresses with existing logic hashToIPv4 method(We are using older kubernates build which is on v3.12.3 )
For bug fix: https://github.com/projectcalico/calico/issues/5146